### PR TITLE
Moves Item/Mobile locks to a handler.

### DIFF
--- a/Scripts/Engines/Quests/The Summoning/Mobiles/Chyloth.cs
+++ b/Scripts/Engines/Quests/The Summoning/Mobiles/Chyloth.cs
@@ -177,21 +177,20 @@ namespace Server.Engines.Quests.Doom
 
         Party p = PartySystem.Party.Get(from);
 
-        if (p != null)
-          for (int i = 0; i < p.Members.Count; ++i)
+        for (int i = 0; i < p?.Members.Count; ++i)
+        {
+          PartyMemberInfo pmi = p.Members[i];
+          Mobile member = pmi.Mobile;
+
+          if (member != from && member.Map == Map.Malas && member.Region.IsPartOf("Doom"))
           {
-            PartyMemberInfo pmi = p.Members[i];
-            Mobile member = pmi.Mobile;
+            if (AngryAt == member)
+              AngryAt = null;
 
-            if (member != from && member.Map == Map.Malas && member.Region.IsPartOf("Doom"))
-            {
-              if (AngryAt == member)
-                AngryAt = null;
-
-              member.CloseGump<ChylothPartyGump>();
-              member.SendGump(new ChylothPartyGump(from, member));
-            }
+            member.CloseGump<ChylothPartyGump>();
+            member.SendGump(new ChylothPartyGump(from, member));
           }
+        }
 
         if (AngryAt == from)
           AngryAt = null;

--- a/Scripts/Items/Special/House Raffle/HouseRaffleStone.cs
+++ b/Scripts/Items/Special/House Raffle/HouseRaffleStone.cs
@@ -16,10 +16,7 @@ namespace Server.Items
     {
       From = from;
 
-      if (From.NetState != null)
-        Address = From.NetState.Address;
-      else
-        Address = IPAddress.None;
+      Address = From.NetState?.Address ?? IPAddress.None;
 
       Date = DateTime.UtcNow;
     }
@@ -367,9 +364,7 @@ namespace Server.Items
 
     public string FormatPrice()
     {
-      if (m_TicketPrice == 0)
-        return "FREE";
-      return $"{m_TicketPrice} gold";
+      return m_TicketPrice == 0 ? "FREE" : $"{m_TicketPrice} gold";
     }
 
     public override void GetProperties(ObjectPropertyList list)

--- a/Server/Item.cs
+++ b/Server/Item.cs
@@ -3736,8 +3736,6 @@ namespace Server
 
     #endregion
 
-    private ObjectPropertyList m_PropertyList;
-
     #region Location Location Location!
 
     public virtual void OnLocationChange(Point3D oldLocation)

--- a/Server/Item.cs
+++ b/Server/Item.cs
@@ -32,177 +32,6 @@ using Server.Targeting;
 namespace Server
 {
   /// <summary>
-  ///   Enumeration of item layer values.
-  /// </summary>
-  public enum Layer : byte
-  {
-    /// <summary>
-    ///   Invalid layer.
-    /// </summary>
-    Invalid = 0x00,
-
-    /// <summary>
-    ///   First valid layer. Equivalent to <c>Layer.OneHanded</c>.
-    /// </summary>
-    FirstValid = 0x01,
-
-    /// <summary>
-    ///   One handed weapon.
-    /// </summary>
-    OneHanded = 0x01,
-
-    /// <summary>
-    ///   Two handed weapon or shield.
-    /// </summary>
-    TwoHanded = 0x02,
-
-    /// <summary>
-    ///   Shoes.
-    /// </summary>
-    Shoes = 0x03,
-
-    /// <summary>
-    ///   Pants.
-    /// </summary>
-    Pants = 0x04,
-
-    /// <summary>
-    ///   Shirts.
-    /// </summary>
-    Shirt = 0x05,
-
-    /// <summary>
-    ///   Helmets, hats, and masks.
-    /// </summary>
-    Helm = 0x06,
-
-    /// <summary>
-    ///   Gloves.
-    /// </summary>
-    Gloves = 0x07,
-
-    /// <summary>
-    ///   Rings.
-    /// </summary>
-    Ring = 0x08,
-
-    /// <summary>
-    ///   Talismans.
-    /// </summary>
-    Talisman = 0x09,
-
-    /// <summary>
-    ///   Gorgets and necklaces.
-    /// </summary>
-    Neck = 0x0A,
-
-    /// <summary>
-    ///   Hair.
-    /// </summary>
-    Hair = 0x0B,
-
-    /// <summary>
-    ///   Half aprons.
-    /// </summary>
-    Waist = 0x0C,
-
-    /// <summary>
-    ///   Torso, inner layer.
-    /// </summary>
-    InnerTorso = 0x0D,
-
-    /// <summary>
-    ///   Bracelets.
-    /// </summary>
-    Bracelet = 0x0E,
-
-    /// <summary>
-    ///   Unused.
-    /// </summary>
-    Unused_xF = 0x0F,
-
-    /// <summary>
-    ///   Beards and mustaches.
-    /// </summary>
-    FacialHair = 0x10,
-
-    /// <summary>
-    ///   Torso, outer layer.
-    /// </summary>
-    MiddleTorso = 0x11,
-
-    /// <summary>
-    ///   Earings.
-    /// </summary>
-    Earrings = 0x12,
-
-    /// <summary>
-    ///   Arms and sleeves.
-    /// </summary>
-    Arms = 0x13,
-
-    /// <summary>
-    ///   Cloaks.
-    /// </summary>
-    Cloak = 0x14,
-
-    /// <summary>
-    ///   Backpacks.
-    /// </summary>
-    Backpack = 0x15,
-
-    /// <summary>
-    ///   Torso, outer layer.
-    /// </summary>
-    OuterTorso = 0x16,
-
-    /// <summary>
-    ///   Leggings, outer layer.
-    /// </summary>
-    OuterLegs = 0x17,
-
-    /// <summary>
-    ///   Leggings, inner layer.
-    /// </summary>
-    InnerLegs = 0x18,
-
-    /// <summary>
-    ///   Last valid non-internal layer. Equivalent to <c>Layer.InnerLegs</c>.
-    /// </summary>
-    LastUserValid = 0x18,
-
-    /// <summary>
-    ///   Mount item layer.
-    /// </summary>
-    Mount = 0x19,
-
-    /// <summary>
-    ///   Vendor 'buy pack' layer.
-    /// </summary>
-    ShopBuy = 0x1A,
-
-    /// <summary>
-    ///   Vendor 'resale pack' layer.
-    /// </summary>
-    ShopResale = 0x1B,
-
-    /// <summary>
-    ///   Vendor 'sell pack' layer.
-    /// </summary>
-    ShopSell = 0x1C,
-
-    /// <summary>
-    ///   Bank box layer.
-    /// </summary>
-    Bank = 0x1D,
-
-    /// <summary>
-    ///   Last valid layer. Equivalent to <c>Layer.Bank</c>.
-    /// </summary>
-    LastValid = 0x1D
-  }
-
-  /// <summary>
   ///   Internal flags used to signal how the item should be updated and resent to nearby clients.
   /// </summary>
   [Flags]
@@ -248,295 +77,6 @@ namespace Server
     ///   The item should be placed into the owners backpack.
     /// </summary>
     MoveToBackpack
-  }
-
-  /// <summary>
-  ///   Enumeration containing all possible light types. These are only applicable to light source items, like lanterns, candles,
-  ///   braziers, etc.
-  /// </summary>
-  public enum LightType
-  {
-    /// <summary>
-    ///   Window shape, arched, ray shining east.
-    /// </summary>
-    ArchedWindowEast,
-
-    /// <summary>
-    ///   Medium circular shape.
-    /// </summary>
-    Circle225,
-
-    /// <summary>
-    ///   Small circular shape.
-    /// </summary>
-    Circle150,
-
-    /// <summary>
-    ///   Door shape, shining south.
-    /// </summary>
-    DoorSouth,
-
-    /// <summary>
-    ///   Door shape, shining east.
-    /// </summary>
-    DoorEast,
-
-    /// <summary>
-    ///   Large semicircular shape (180 degrees), north wall.
-    /// </summary>
-    NorthBig,
-
-    /// <summary>
-    ///   Large pie shape (90 degrees), north-east corner.
-    /// </summary>
-    NorthEastBig,
-
-    /// <summary>
-    ///   Large semicircular shape (180 degrees), east wall.
-    /// </summary>
-    EastBig,
-
-    /// <summary>
-    ///   Large semicircular shape (180 degrees), west wall.
-    /// </summary>
-    WestBig,
-
-    /// <summary>
-    ///   Large pie shape (90 degrees), south-west corner.
-    /// </summary>
-    SouthWestBig,
-
-    /// <summary>
-    ///   Large semicircular shape (180 degrees), south wall.
-    /// </summary>
-    SouthBig,
-
-    /// <summary>
-    ///   Medium semicircular shape (180 degrees), north wall.
-    /// </summary>
-    NorthSmall,
-
-    /// <summary>
-    ///   Medium pie shape (90 degrees), north-east corner.
-    /// </summary>
-    NorthEastSmall,
-
-    /// <summary>
-    ///   Medium semicircular shape (180 degrees), east wall.
-    /// </summary>
-    EastSmall,
-
-    /// <summary>
-    ///   Medium semicircular shape (180 degrees), west wall.
-    /// </summary>
-    WestSmall,
-
-    /// <summary>
-    ///   Medium semicircular shape (180 degrees), south wall.
-    /// </summary>
-    SouthSmall,
-
-    /// <summary>
-    ///   Shaped like a wall decoration, north wall.
-    /// </summary>
-    DecorationNorth,
-
-    /// <summary>
-    ///   Shaped like a wall decoration, north-east corner.
-    /// </summary>
-    DecorationNorthEast,
-
-    /// <summary>
-    ///   Small semicircular shape (180 degrees), east wall.
-    /// </summary>
-    EastTiny,
-
-    /// <summary>
-    ///   Shaped like a wall decoration, west wall.
-    /// </summary>
-    DecorationWest,
-
-    /// <summary>
-    ///   Shaped like a wall decoration, south-west corner.
-    /// </summary>
-    DecorationSouthWest,
-
-    /// <summary>
-    ///   Small semicircular shape (180 degrees), south wall.
-    /// </summary>
-    SouthTiny,
-
-    /// <summary>
-    ///   Window shape, rectangular, no ray, shining south.
-    /// </summary>
-    RectWindowSouthNoRay,
-
-    /// <summary>
-    ///   Window shape, rectangular, no ray, shining east.
-    /// </summary>
-    RectWindowEastNoRay,
-
-    /// <summary>
-    ///   Window shape, rectangular, ray shining south.
-    /// </summary>
-    RectWindowSouth,
-
-    /// <summary>
-    ///   Window shape, rectangular, ray shining east.
-    /// </summary>
-    RectWindowEast,
-
-    /// <summary>
-    ///   Window shape, arched, no ray, shining south.
-    /// </summary>
-    ArchedWindowSouthNoRay,
-
-    /// <summary>
-    ///   Window shape, arched, no ray, shining east.
-    /// </summary>
-    ArchedWindowEastNoRay,
-
-    /// <summary>
-    ///   Window shape, arched, ray shining south.
-    /// </summary>
-    ArchedWindowSouth,
-
-    /// <summary>
-    ///   Large circular shape.
-    /// </summary>
-    Circle300,
-
-    /// <summary>
-    ///   Large pie shape (90 degrees), north-west corner.
-    /// </summary>
-    NorthWestBig,
-
-    /// <summary>
-    ///   Negative light. Medium pie shape (90 degrees), south-east corner.
-    /// </summary>
-    DarkSouthEast,
-
-    /// <summary>
-    ///   Negative light. Medium semicircular shape (180 degrees), south wall.
-    /// </summary>
-    DarkSouth,
-
-    /// <summary>
-    ///   Negative light. Medium pie shape (90 degrees), north-west corner.
-    /// </summary>
-    DarkNorthWest,
-
-    /// <summary>
-    ///   Negative light. Medium pie shape (90 degrees), south-east corner. Equivalent to <c>LightType.SouthEast</c>.
-    /// </summary>
-    DarkSouthEast2,
-
-    /// <summary>
-    ///   Negative light. Medium circular shape (180 degrees), east wall.
-    /// </summary>
-    DarkEast,
-
-    /// <summary>
-    ///   Negative light. Large circular shape.
-    /// </summary>
-    DarkCircle300,
-
-    /// <summary>
-    ///   Opened door shape, shining south.
-    /// </summary>
-    DoorOpenSouth,
-
-    /// <summary>
-    ///   Opened door shape, shining east.
-    /// </summary>
-    DoorOpenEast,
-
-    /// <summary>
-    ///   Window shape, square, ray shining east.
-    /// </summary>
-    SquareWindowEast,
-
-    /// <summary>
-    ///   Window shape, square, no ray, shining east.
-    /// </summary>
-    SquareWindowEastNoRay,
-
-    /// <summary>
-    ///   Window shape, square, ray shining south.
-    /// </summary>
-    SquareWindowSouth,
-
-    /// <summary>
-    ///   Window shape, square, no ray, shining south.
-    /// </summary>
-    SquareWindowSouthNoRay,
-
-    /// <summary>
-    ///   Empty.
-    /// </summary>
-    Empty,
-
-    /// <summary>
-    ///   Window shape, skinny, no ray, shining south.
-    /// </summary>
-    SkinnyWindowSouthNoRay,
-
-    /// <summary>
-    ///   Window shape, skinny, ray shining east.
-    /// </summary>
-    SkinnyWindowEast,
-
-    /// <summary>
-    ///   Window shape, skinny, no ray, shining east.
-    /// </summary>
-    SkinnyWindowEastNoRay,
-
-    /// <summary>
-    ///   Shaped like a hole, shining south.
-    /// </summary>
-    HoleSouth,
-
-    /// <summary>
-    ///   Shaped like a hole, shining south.
-    /// </summary>
-    HoleEast,
-
-    /// <summary>
-    ///   Large circular shape with a moongate graphic embedded.
-    /// </summary>
-    Moongate,
-
-    /// <summary>
-    ///   Unknown usage. Many rows of slightly angled lines.
-    /// </summary>
-    Strips,
-
-    /// <summary>
-    ///   Shaped like a small hole, shining south.
-    /// </summary>
-    SmallHoleSouth,
-
-    /// <summary>
-    ///   Shaped like a small hole, shining east.
-    /// </summary>
-    SmallHoleEast,
-
-    /// <summary>
-    ///   Large semicircular shape (180 degrees), north wall. Identical graphic as <c>LightType.NorthBig</c>, but slightly different
-    ///   positioning.
-    /// </summary>
-    NorthBig2,
-
-    /// <summary>
-    ///   Large semicircular shape (180 degrees), west wall. Identical graphic as <c>LightType.WestBig</c>, but slightly different
-    ///   positioning.
-    /// </summary>
-    WestBig2,
-
-    /// <summary>
-    ///   Large pie shape (90 degrees), north-west corner. Equivalent to <c>LightType.NorthWestBig</c>.
-    /// </summary>
-    NorthWestBig2
   }
 
   /// <summary>
@@ -659,7 +199,7 @@ namespace Server
     Spawner = 0x100
   }
 
-  public class Item : IHued, IComparable<Item>, ISerializable, ISpawnable
+  public class Item : IHued, IComparable<Item>, ISerializable, ISpawnable, IPropertyListObject
   {
     public const int QuestItemHue = 0x4EA; // Hmmmm... "for EA"?
     public static readonly List<Item> EmptyItems = new List<Item>();
@@ -669,14 +209,6 @@ namespace Server
     private static bool _processing;
 
     private static int m_OpenSlots;
-
-    private object _opll = new object();
-
-    private object _rpl = new object();
-
-    private object _wpl = new object();
-    private object _wplhs = new object();
-    private object _wplsa = new object();
 
     private CompactInfo m_CompactInfo;
 
@@ -808,138 +340,20 @@ namespace Server
       set => SetFlag(ImplFlag.Stackable, value);
     }
 
-    public Packet RemovePacket
-    {
-      get
-      {
-        if (m_RemovePacket == null)
-          lock (_rpl)
-          {
-            if (m_RemovePacket == null)
-            {
-              m_RemovePacket = new RemoveItem(this);
-              m_RemovePacket.SetStatic();
-            }
-          }
+    public Packet RemovePacket => StaticPacketHandlers.GetRemoveEntityPacket(this);
+    public OPLInfo OPLPacket => StaticPacketHandlers.GetOPLInfoPacket(this);
+    public ObjectPropertyList PropertyList => StaticPacketHandlers.GetOPLPacket(this);
 
-        return m_RemovePacket;
-      }
-    }
-
-    public Packet OPLPacket
-    {
-      get
-      {
-        if (m_OPLPacket == null)
-          lock (_opll)
-          {
-            if (m_OPLPacket == null)
-            {
-              m_OPLPacket = new OPLInfo(PropertyList);
-              m_OPLPacket.SetStatic();
-            }
-          }
-
-        return m_OPLPacket;
-      }
-    }
-
-    public ObjectPropertyList PropertyList
-    {
-      get
-      {
-        if (m_PropertyList == null)
-        {
-          m_PropertyList = new ObjectPropertyList(this);
-
-          GetProperties(m_PropertyList);
-          AppendChildProperties(m_PropertyList);
-
-          m_PropertyList.Terminate();
-          m_PropertyList.SetStatic();
-        }
-
-        return m_PropertyList;
-      }
-    }
-
-    public Packet WorldPacket
-    {
-      get
-      {
-        // This needs to be invalidated when any of the following changes:
-        //  - ItemID
-        //  - Amount
-        //  - Location
-        //  - Hue
-        //  - Packet Flags
-        //  - Direction
-
-        if (m_WorldPacket == null)
-          lock (_wpl)
-          {
-            if (m_WorldPacket == null)
-            {
-              m_WorldPacket = new WorldItem(this);
-              m_WorldPacket.SetStatic();
-            }
-          }
-
-        return m_WorldPacket;
-      }
-    }
-
-    public Packet WorldPacketSA
-    {
-      get
-      {
-        // This needs to be invalidated when any of the following changes:
-        //  - ItemID
-        //  - Amount
-        //  - Location
-        //  - Hue
-        //  - Packet Flags
-        //  - Direction
-
-        if (m_WorldPacketSA == null)
-          lock (_wplsa)
-          {
-            if (m_WorldPacketSA == null)
-            {
-              m_WorldPacketSA = new WorldItemSA(this);
-              m_WorldPacketSA.SetStatic();
-            }
-          }
-
-        return m_WorldPacketSA;
-      }
-    }
-
-    public Packet WorldPacketHS
-    {
-      get
-      {
-        // This needs to be invalidated when any of the following changes:
-        //  - ItemID
-        //  - Amount
-        //  - Location
-        //  - Hue
-        //  - Packet Flags
-        //  - Direction
-
-        if (m_WorldPacketHS == null)
-          lock (_wplhs)
-          {
-            if (m_WorldPacketHS == null)
-            {
-              m_WorldPacketHS = new WorldItemHS(this);
-              m_WorldPacketHS.SetStatic();
-            }
-          }
-
-        return m_WorldPacketHS;
-      }
-    }
+    // World packets need to be invalidated when any of the following changes:
+    //  - ItemID
+    //  - Amount
+    //  - Location
+    //  - Hue
+    //  - Packet Flags
+    //  - Direction
+    public Packet WorldPacket => StaticPacketHandlers.GetWorldItemPacket(this);
+    public Packet WorldPacketSA => StaticPacketHandlers.GetWorldItemSAPacket(this);
+    public Packet WorldPacketHS => StaticPacketHandlers.GetWorldItemHSPacket(this);
 
     [CommandProperty(AccessLevel.GameMaster)]
     public bool Visible
@@ -2639,8 +2053,8 @@ namespace Server
 
     public void ClearProperties()
     {
-      Packet.Release(ref m_PropertyList);
-      Packet.Release(ref m_OPLPacket);
+      StaticPacketHandlers.FreeOPLPacket(this);
+      StaticPacketHandlers.FreeOPLInfoPacket(this);
     }
 
     public void InvalidateProperties()
@@ -2650,12 +2064,11 @@ namespace Server
 
       if (m_Map != null && m_Map != Map.Internal && !World.Loading)
       {
-        ObjectPropertyList oldList = m_PropertyList;
-        m_PropertyList = null;
+        ObjectPropertyList oldList = StaticPacketHandlers.FreeOPLPacket(this);
 
         if (oldList?.Hash != PropertyList.Hash)
         {
-          Packet.Release(ref m_OPLPacket);
+          StaticPacketHandlers.FreeOPLInfoPacket(this);
           Delta(ItemDelta.Properties);
         }
       }
@@ -2667,9 +2080,7 @@ namespace Server
 
     public void ReleaseWorldPackets()
     {
-      Packet.Release(ref m_WorldPacket);
-      Packet.Release(ref m_WorldPacketSA);
-      Packet.Release(ref m_WorldPacketHS);
+      StaticPacketHandlers.FreeWorldItemPackets(this);
     }
 
     public virtual int GetPacketFlags()
@@ -3423,9 +2834,9 @@ namespace Server
     public virtual void FreeCache()
     {
       ReleaseWorldPackets();
-      Packet.Release(ref m_RemovePacket);
-      Packet.Release(ref m_OPLPacket);
-      Packet.Release(ref m_PropertyList);
+      StaticPacketHandlers.FreeRemoveItemPacket(this);
+      StaticPacketHandlers.FreeOPLInfoPacket(this);
+      StaticPacketHandlers.FreeOPLPacket(this);
     }
 
     public void PublicOverheadMessage(MessageType type, int hue, bool ascii, string text)
@@ -4325,17 +3736,7 @@ namespace Server
 
     #endregion
 
-    #region Packet caches
-
-    private Packet m_WorldPacket;
-    private Packet m_WorldPacketSA;
-    private Packet m_WorldPacketHS;
-    private Packet m_RemovePacket;
-
-    private Packet m_OPLPacket;
     private ObjectPropertyList m_PropertyList;
-
-    #endregion
 
     #region Location Location Location!
 

--- a/Server/Layer.cs
+++ b/Server/Layer.cs
@@ -1,0 +1,173 @@
+namespace Server
+{
+  /// <summary>
+  ///   Enumeration of item layer values.
+  /// </summary>
+  public enum Layer : byte
+  {
+    /// <summary>
+    ///   Invalid layer.
+    /// </summary>
+    Invalid = 0x00,
+
+    /// <summary>
+    ///   First valid layer. Equivalent to <c>Layer.OneHanded</c>.
+    /// </summary>
+    FirstValid = 0x01,
+
+    /// <summary>
+    ///   One handed weapon.
+    /// </summary>
+    OneHanded = 0x01,
+
+    /// <summary>
+    ///   Two handed weapon or shield.
+    /// </summary>
+    TwoHanded = 0x02,
+
+    /// <summary>
+    ///   Shoes.
+    /// </summary>
+    Shoes = 0x03,
+
+    /// <summary>
+    ///   Pants.
+    /// </summary>
+    Pants = 0x04,
+
+    /// <summary>
+    ///   Shirts.
+    /// </summary>
+    Shirt = 0x05,
+
+    /// <summary>
+    ///   Helmets, hats, and masks.
+    /// </summary>
+    Helm = 0x06,
+
+    /// <summary>
+    ///   Gloves.
+    /// </summary>
+    Gloves = 0x07,
+
+    /// <summary>
+    ///   Rings.
+    /// </summary>
+    Ring = 0x08,
+
+    /// <summary>
+    ///   Talismans.
+    /// </summary>
+    Talisman = 0x09,
+
+    /// <summary>
+    ///   Gorgets and necklaces.
+    /// </summary>
+    Neck = 0x0A,
+
+    /// <summary>
+    ///   Hair.
+    /// </summary>
+    Hair = 0x0B,
+
+    /// <summary>
+    ///   Half aprons.
+    /// </summary>
+    Waist = 0x0C,
+
+    /// <summary>
+    ///   Torso, inner layer.
+    /// </summary>
+    InnerTorso = 0x0D,
+
+    /// <summary>
+    ///   Bracelets.
+    /// </summary>
+    Bracelet = 0x0E,
+
+    /// <summary>
+    ///   Unused.
+    /// </summary>
+    Unused_xF = 0x0F,
+
+    /// <summary>
+    ///   Beards and mustaches.
+    /// </summary>
+    FacialHair = 0x10,
+
+    /// <summary>
+    ///   Torso, outer layer.
+    /// </summary>
+    MiddleTorso = 0x11,
+
+    /// <summary>
+    ///   Earings.
+    /// </summary>
+    Earrings = 0x12,
+
+    /// <summary>
+    ///   Arms and sleeves.
+    /// </summary>
+    Arms = 0x13,
+
+    /// <summary>
+    ///   Cloaks.
+    /// </summary>
+    Cloak = 0x14,
+
+    /// <summary>
+    ///   Backpacks.
+    /// </summary>
+    Backpack = 0x15,
+
+    /// <summary>
+    ///   Torso, outer layer.
+    /// </summary>
+    OuterTorso = 0x16,
+
+    /// <summary>
+    ///   Leggings, outer layer.
+    /// </summary>
+    OuterLegs = 0x17,
+
+    /// <summary>
+    ///   Leggings, inner layer.
+    /// </summary>
+    InnerLegs = 0x18,
+
+    /// <summary>
+    ///   Last valid non-internal layer. Equivalent to <c>Layer.InnerLegs</c>.
+    /// </summary>
+    LastUserValid = 0x18,
+
+    /// <summary>
+    ///   Mount item layer.
+    /// </summary>
+    Mount = 0x19,
+
+    /// <summary>
+    ///   Vendor 'buy pack' layer.
+    /// </summary>
+    ShopBuy = 0x1A,
+
+    /// <summary>
+    ///   Vendor 'resale pack' layer.
+    /// </summary>
+    ShopResale = 0x1B,
+
+    /// <summary>
+    ///   Vendor 'sell pack' layer.
+    /// </summary>
+    ShopSell = 0x1C,
+
+    /// <summary>
+    ///   Bank box layer.
+    /// </summary>
+    Bank = 0x1D,
+
+    /// <summary>
+    ///   Last valid layer. Equivalent to <c>Layer.Bank</c>.
+    /// </summary>
+    LastValid = 0x1D
+  }
+}

--- a/Server/LightType.cs
+++ b/Server/LightType.cs
@@ -1,0 +1,287 @@
+namespace Server
+{
+  public enum LightType
+  {
+    /// <summary>
+    ///   Window shape, arched, ray shining east.
+    /// </summary>
+    ArchedWindowEast,
+
+    /// <summary>
+    ///   Medium circular shape.
+    /// </summary>
+    Circle225,
+
+    /// <summary>
+    ///   Small circular shape.
+    /// </summary>
+    Circle150,
+
+    /// <summary>
+    ///   Door shape, shining south.
+    /// </summary>
+    DoorSouth,
+
+    /// <summary>
+    ///   Door shape, shining east.
+    /// </summary>
+    DoorEast,
+
+    /// <summary>
+    ///   Large semicircular shape (180 degrees), north wall.
+    /// </summary>
+    NorthBig,
+
+    /// <summary>
+    ///   Large pie shape (90 degrees), north-east corner.
+    /// </summary>
+    NorthEastBig,
+
+    /// <summary>
+    ///   Large semicircular shape (180 degrees), east wall.
+    /// </summary>
+    EastBig,
+
+    /// <summary>
+    ///   Large semicircular shape (180 degrees), west wall.
+    /// </summary>
+    WestBig,
+
+    /// <summary>
+    ///   Large pie shape (90 degrees), south-west corner.
+    /// </summary>
+    SouthWestBig,
+
+    /// <summary>
+    ///   Large semicircular shape (180 degrees), south wall.
+    /// </summary>
+    SouthBig,
+
+    /// <summary>
+    ///   Medium semicircular shape (180 degrees), north wall.
+    /// </summary>
+    NorthSmall,
+
+    /// <summary>
+    ///   Medium pie shape (90 degrees), north-east corner.
+    /// </summary>
+    NorthEastSmall,
+
+    /// <summary>
+    ///   Medium semicircular shape (180 degrees), east wall.
+    /// </summary>
+    EastSmall,
+
+    /// <summary>
+    ///   Medium semicircular shape (180 degrees), west wall.
+    /// </summary>
+    WestSmall,
+
+    /// <summary>
+    ///   Medium semicircular shape (180 degrees), south wall.
+    /// </summary>
+    SouthSmall,
+
+    /// <summary>
+    ///   Shaped like a wall decoration, north wall.
+    /// </summary>
+    DecorationNorth,
+
+    /// <summary>
+    ///   Shaped like a wall decoration, north-east corner.
+    /// </summary>
+    DecorationNorthEast,
+
+    /// <summary>
+    ///   Small semicircular shape (180 degrees), east wall.
+    /// </summary>
+    EastTiny,
+
+    /// <summary>
+    ///   Shaped like a wall decoration, west wall.
+    /// </summary>
+    DecorationWest,
+
+    /// <summary>
+    ///   Shaped like a wall decoration, south-west corner.
+    /// </summary>
+    DecorationSouthWest,
+
+    /// <summary>
+    ///   Small semicircular shape (180 degrees), south wall.
+    /// </summary>
+    SouthTiny,
+
+    /// <summary>
+    ///   Window shape, rectangular, no ray, shining south.
+    /// </summary>
+    RectWindowSouthNoRay,
+
+    /// <summary>
+    ///   Window shape, rectangular, no ray, shining east.
+    /// </summary>
+    RectWindowEastNoRay,
+
+    /// <summary>
+    ///   Window shape, rectangular, ray shining south.
+    /// </summary>
+    RectWindowSouth,
+
+    /// <summary>
+    ///   Window shape, rectangular, ray shining east.
+    /// </summary>
+    RectWindowEast,
+
+    /// <summary>
+    ///   Window shape, arched, no ray, shining south.
+    /// </summary>
+    ArchedWindowSouthNoRay,
+
+    /// <summary>
+    ///   Window shape, arched, no ray, shining east.
+    /// </summary>
+    ArchedWindowEastNoRay,
+
+    /// <summary>
+    ///   Window shape, arched, ray shining south.
+    /// </summary>
+    ArchedWindowSouth,
+
+    /// <summary>
+    ///   Large circular shape.
+    /// </summary>
+    Circle300,
+
+    /// <summary>
+    ///   Large pie shape (90 degrees), north-west corner.
+    /// </summary>
+    NorthWestBig,
+
+    /// <summary>
+    ///   Negative light. Medium pie shape (90 degrees), south-east corner.
+    /// </summary>
+    DarkSouthEast,
+
+    /// <summary>
+    ///   Negative light. Medium semicircular shape (180 degrees), south wall.
+    /// </summary>
+    DarkSouth,
+
+    /// <summary>
+    ///   Negative light. Medium pie shape (90 degrees), north-west corner.
+    /// </summary>
+    DarkNorthWest,
+
+    /// <summary>
+    ///   Negative light. Medium pie shape (90 degrees), south-east corner. Equivalent to <c>LightType.SouthEast</c>.
+    /// </summary>
+    DarkSouthEast2,
+
+    /// <summary>
+    ///   Negative light. Medium circular shape (180 degrees), east wall.
+    /// </summary>
+    DarkEast,
+
+    /// <summary>
+    ///   Negative light. Large circular shape.
+    /// </summary>
+    DarkCircle300,
+
+    /// <summary>
+    ///   Opened door shape, shining south.
+    /// </summary>
+    DoorOpenSouth,
+
+    /// <summary>
+    ///   Opened door shape, shining east.
+    /// </summary>
+    DoorOpenEast,
+
+    /// <summary>
+    ///   Window shape, square, ray shining east.
+    /// </summary>
+    SquareWindowEast,
+
+    /// <summary>
+    ///   Window shape, square, no ray, shining east.
+    /// </summary>
+    SquareWindowEastNoRay,
+
+    /// <summary>
+    ///   Window shape, square, ray shining south.
+    /// </summary>
+    SquareWindowSouth,
+
+    /// <summary>
+    ///   Window shape, square, no ray, shining south.
+    /// </summary>
+    SquareWindowSouthNoRay,
+
+    /// <summary>
+    ///   Empty.
+    /// </summary>
+    Empty,
+
+    /// <summary>
+    ///   Window shape, skinny, no ray, shining south.
+    /// </summary>
+    SkinnyWindowSouthNoRay,
+
+    /// <summary>
+    ///   Window shape, skinny, ray shining east.
+    /// </summary>
+    SkinnyWindowEast,
+
+    /// <summary>
+    ///   Window shape, skinny, no ray, shining east.
+    /// </summary>
+    SkinnyWindowEastNoRay,
+
+    /// <summary>
+    ///   Shaped like a hole, shining south.
+    /// </summary>
+    HoleSouth,
+
+    /// <summary>
+    ///   Shaped like a hole, shining south.
+    /// </summary>
+    HoleEast,
+
+    /// <summary>
+    ///   Large circular shape with a moongate graphic embedded.
+    /// </summary>
+    Moongate,
+
+    /// <summary>
+    ///   Unknown usage. Many rows of slightly angled lines.
+    /// </summary>
+    Strips,
+
+    /// <summary>
+    ///   Shaped like a small hole, shining south.
+    /// </summary>
+    SmallHoleSouth,
+
+    /// <summary>
+    ///   Shaped like a small hole, shining east.
+    /// </summary>
+    SmallHoleEast,
+
+    /// <summary>
+    ///   Large semicircular shape (180 degrees), north wall. Identical graphic as <c>LightType.NorthBig</c>, but slightly different
+    ///   positioning.
+    /// </summary>
+    NorthBig2,
+
+    /// <summary>
+    ///   Large semicircular shape (180 degrees), west wall. Identical graphic as <c>LightType.WestBig</c>, but slightly different
+    ///   positioning.
+    /// </summary>
+    WestBig2,
+
+    /// <summary>
+    ///   Large pie shape (90 degrees), north-west corner. Equivalent to <c>LightType.NorthWestBig</c>.
+    /// </summary>
+    NorthWestBig2
+  }
+}

--- a/Server/Mobile.cs
+++ b/Server/Mobile.cs
@@ -6787,9 +6787,8 @@ namespace Server
       {
         ObjectPropertyList oldList = m_PropertyList;
         Packet.Release(ref m_PropertyList);
-        ObjectPropertyList newList = PropertyList;
 
-        if (oldList == null || oldList.Hash != newList.Hash)
+        if (oldList?.Hash != PropertyList.Hash)
         {
           Packet.Release(ref m_OPLPacket);
           Delta(MobileDelta.Properties);

--- a/Server/Network/Packets.cs
+++ b/Server/Network/Packets.cs
@@ -1035,9 +1035,8 @@ namespace Server.Network
 
       int hue = item.Hue;
 
-      if (parent != null)
-        if (parent.SolidHueOverride >= 0)
-          hue = parent.SolidHueOverride;
+      if (parent?.SolidHueOverride >= 0)
+        hue = parent.SolidHueOverride;
 
       m_Stream.Write(item.Serial);
       m_Stream.Write((short)item.ItemID);

--- a/Server/Network/Packets.cs
+++ b/Server/Network/Packets.cs
@@ -2018,19 +2018,11 @@ namespace Server.Network
     }
   }
 
-  public sealed class RemoveItem : Packet
+  public sealed class RemoveEntity : Packet
   {
-    public RemoveItem(Item item) : base(0x1D, 5)
+    public RemoveEntity(IEntity entity) : base(0x1D, 5)
     {
-      m_Stream.Write(item.Serial);
-    }
-  }
-
-  public sealed class RemoveMobile : Packet
-  {
-    public RemoveMobile(Mobile m) : base(0x1D, 5)
-    {
-      m_Stream.Write(m.Serial);
+      m_Stream.Write(entity.Serial);
     }
   }
 
@@ -4365,35 +4357,24 @@ namespace Server.Network
     public static void Release(ref ObjectPropertyList p)
     {
       p?.Release();
-
       p = null;
     }
 
-    public static void Release(ref RemoveItem p)
+    public static void Release(ref RemoveEntity p)
     {
       p?.Release();
-
-      p = null;
-    }
-
-    public static void Release(ref RemoveMobile p)
-    {
-      p?.Release();
-
       p = null;
     }
 
     public static void Release(ref OPLInfo p)
     {
       p?.Release();
-
       p = null;
     }
 
     public static void Release(ref Packet p)
     {
       p?.Release();
-
       p = null;
     }
 

--- a/Server/Network/Packets.cs
+++ b/Server/Network/Packets.cs
@@ -4354,24 +4354,6 @@ namespace Server.Network
       return p;
     }
 
-    public static void Release(ref ObjectPropertyList p)
-    {
-      p?.Release();
-      p = null;
-    }
-
-    public static void Release(ref RemoveEntity p)
-    {
-      p?.Release();
-      p = null;
-    }
-
-    public static void Release(ref OPLInfo p)
-    {
-      p?.Release();
-      p = null;
-    }
-
     public static void Release(ref Packet p)
     {
       p?.Release();

--- a/Server/Network/StaticPacketHandlers.cs
+++ b/Server/Network/StaticPacketHandlers.cs
@@ -1,0 +1,115 @@
+using System.Collections.Concurrent;
+
+namespace Server.Network
+{
+  public static class StaticPacketHandlers
+  {
+    private static ConcurrentDictionary<IPropertyListObject,OPLInfo> OPLInfoPackets = new ConcurrentDictionary<IPropertyListObject,OPLInfo>();
+    private static ConcurrentDictionary<IPropertyListObject,ObjectPropertyList> ObjectPropertyListPackets = new ConcurrentDictionary<IPropertyListObject,ObjectPropertyList>();
+    private static ConcurrentDictionary<IEntity,RemoveEntity> RemoveEntityPackets = new ConcurrentDictionary<IEntity,RemoveEntity>();
+
+    private static ConcurrentDictionary<Item,WorldItem> WorldItemPackets = new ConcurrentDictionary<Item,WorldItem>();
+    private static ConcurrentDictionary<Item,WorldItemSA> WorldItemSAPackets = new ConcurrentDictionary<Item,WorldItemSA>();
+    private static ConcurrentDictionary<Item,WorldItemHS> WorldItemHSPackets = new ConcurrentDictionary<Item,WorldItemHS>();
+
+    public static OPLInfo GetOPLInfoPacket(IPropertyListObject obj)
+    {
+      return OPLInfoPackets.GetOrAdd(obj, value =>
+      {
+        OPLInfo packet = new OPLInfo(value.PropertyList);
+        packet.SetStatic();
+        return packet;
+      });
+    }
+
+    public static OPLInfo FreeOPLInfoPacket(IPropertyListObject obj)
+    {
+      if (OPLInfoPackets.TryRemove(obj, out OPLInfo p))
+        Packet.Release(p);
+
+      return p;
+    }
+
+    public static ObjectPropertyList GetOPLPacket(IPropertyListObject obj)
+    {
+      return ObjectPropertyListPackets.GetOrAdd(obj, value =>
+      {
+        ObjectPropertyList list = new ObjectPropertyList(value);
+
+        value.GetProperties(list);
+        if (value is Item item)
+          item.AppendChildProperties(list);
+
+        list.Terminate();
+        list.SetStatic();
+        return list;
+      });
+    }
+
+    public static ObjectPropertyList FreeOPLPacket(IPropertyListObject obj)
+    {
+      if (ObjectPropertyListPackets.TryRemove(obj, out ObjectPropertyList list))
+        Packet.Release(list);
+
+      return list;
+    }
+
+    public static RemoveEntity GetRemoveEntityPacket(IEntity entity)
+    {
+      return RemoveEntityPackets.GetOrAdd(entity, value =>
+      {
+        RemoveEntity packet = new RemoveEntity(value);
+        packet.SetStatic();
+        return packet;
+      });
+    }
+
+    public static void FreeRemoveItemPacket(IEntity entity)
+    {
+      if (RemoveEntityPackets.TryRemove(entity, out RemoveEntity p))
+        Packet.Release(p);
+    }
+
+    public static WorldItem GetWorldItemPacket(Item item)
+    {
+      return WorldItemPackets.GetOrAdd(item, value =>
+      {
+        WorldItem packet = new WorldItem(value);
+        packet.SetStatic();
+        return packet;
+      });
+    }
+
+    public static WorldItemSA GetWorldItemSAPacket(Item item)
+    {
+      return WorldItemSAPackets.GetOrAdd(item, value =>
+      {
+        WorldItemSA packet = new WorldItemSA(value);
+        packet.SetStatic();
+        return packet;
+      });
+    }
+
+    public static WorldItemHS GetWorldItemHSPacket(Item item)
+    {
+      return WorldItemHSPackets.GetOrAdd(item, value =>
+      {
+        WorldItemHS packet = new WorldItemHS(value);
+        packet.SetStatic();
+        return packet;
+      });
+    }
+
+    public static void FreeWorldItemPackets(Item item)
+    {
+      if (WorldItemPackets.TryRemove(item, out WorldItem wi))
+        Packet.Release(wi);
+
+      if (WorldItemSAPackets.TryRemove(item, out WorldItemSA wisa))
+        Packet.Release(wisa);
+
+      if (WorldItemHSPackets.TryRemove(item, out WorldItemHS wihs))
+        Packet.Release(wihs);
+    }
+  }
+}

--- a/Server/ObjectPropertyList.cs
+++ b/Server/ObjectPropertyList.cs
@@ -24,6 +24,14 @@ using Server.Network;
 
 namespace Server
 {
+  public interface IPropertyListObject : IEntity
+  {
+    ObjectPropertyList PropertyList{ get; }
+    OPLInfo OPLPacket{ get;  }
+
+    void GetProperties(ObjectPropertyList list);
+  }
+
   public sealed class ObjectPropertyList : Packet
   {
     private static byte[] m_Buffer = new byte[1024];

--- a/Server/Server.csproj
+++ b/Server/Server.csproj
@@ -155,6 +155,8 @@
     <Compile Include="Items\VirtualCheck.cs" />
     <Compile Include="Items\VirtualHair.cs" />
     <Compile Include="KeywordList.cs" />
+    <Compile Include="Layer.cs" />
+    <Compile Include="LightType.cs" />
     <Compile Include="Main.cs" />
     <Compile Include="Map.cs" />
     <Compile Include="Menus\IMenu.cs" />
@@ -169,6 +171,7 @@
     <Compile Include="Network\Compression.cs" />
     <Compile Include="Network\EncodedPacketHandler.cs" />
     <Compile Include="Network\EncodedReader.cs" />
+    <Compile Include="Network\StaticPacketHandlers.cs" />
     <Compile Include="Network\Listener.cs" />
     <Compile Include="Network\MessagePump.cs" />
     <Compile Include="Network\NetState.cs" />


### PR DESCRIPTION
Moves item/mobile locks to a handler. This frees up unused references for the majority of items/mobiles.

Initial test with 15mill items and 1mill mobiles show a 750MB reduction in memory usage.

Also did some cleanup. Sorry for the large diff >.<