### PR TITLE
Cleans up Spell Targeting

### DIFF
--- a/Scripts/Engines/BulkOrders/LargeBOD.cs
+++ b/Scripts/Engines/BulkOrders/LargeBOD.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using Server.Mobiles;
 
 namespace Server.Engines.BulkOrders

--- a/Scripts/Engines/BulkOrders/LargeSmithBOD.cs
+++ b/Scripts/Engines/BulkOrders/LargeSmithBOD.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using Mat = Server.Engines.BulkOrders.BulkMaterialType;
 
 namespace Server.Engines.BulkOrders

--- a/Scripts/Engines/BulkOrders/LargeTailorBOD.cs
+++ b/Scripts/Engines/BulkOrders/LargeTailorBOD.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using Mat = Server.Engines.BulkOrders.BulkMaterialType;
 
 namespace Server.Engines.BulkOrders

--- a/Scripts/Engines/BulkOrders/SmallBOD.cs
+++ b/Scripts/Engines/BulkOrders/SmallBOD.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using Server.Items;
 using Server.Mobiles;
 

--- a/Scripts/Engines/Factions/Mobiles/Guards/GuardAI.cs
+++ b/Scripts/Engines/Factions/Mobiles/Guards/GuardAI.cs
@@ -469,7 +469,7 @@ namespace Server.Factions
           if (m_Guard.Map == toHarm.Map && (targ.Range < 0 || m_Guard.InRange(toHarm, targ.Range)) &&
               m_Guard.CanSee(toHarm) && m_Guard.InLOS(toHarm))
             targ.Invoke(m_Guard, toHarm);
-          else if (targ is DispelSpell.InternalTarget)
+          else if ((targ as ISpellTarget)?.Spell is DispelSpell)
             targ.Cancel(m_Guard, TargetCancelType.Canceled);
         }
         else if ((targ.Flags & TargetFlags.Beneficial) != 0)

--- a/Scripts/Engines/Quests/Core/QuestItemInfo.cs
+++ b/Scripts/Engines/Quests/Core/QuestItemInfo.cs
@@ -1,5 +1,3 @@
-using Server.Gumps;
-
 namespace Server.Engines.Quests
 {
   public class QuestItemInfo

--- a/Scripts/Items/Skill Items/Magical/Potions/Conflagration Potions/BaseConflagrationPotion.cs
+++ b/Scripts/Items/Skill Items/Magical/Potions/Conflagration Potions/BaseConflagrationPotion.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Server.Spells;
 using Server.Targeting;
 

--- a/Scripts/Mobiles/AI/HealerAI.cs
+++ b/Scripts/Mobiles/AI/HealerAI.cs
@@ -1,6 +1,8 @@
+using Server.Spells;
 using Server.Spells.First;
 using Server.Spells.Fourth;
 using Server.Spells.Second;
+using Server.Spells.Sixth;
 using Server.Targeting;
 
 namespace Server.Mobiles
@@ -28,11 +30,13 @@ namespace Server.Mobiles
 
       if (targ != null)
       {
-        if (targ is CureSpell.InternalTarget)
+        ISpellTarget spellTarg = targ as ISpellTarget;
+
+        if (spellTarg?.Spell is CureSpell)
           ProcessTarget(targ, m_ACure);
-        else if (targ is GreaterHealSpell.InternalTarget)
+        else if (spellTarg?.Spell is GreaterHealSpell)
           ProcessTarget(targ, m_AGHeal);
-        else if (targ is HealSpell.InternalTarget)
+        else if (spellTarg?.Spell is HealSpell)
           ProcessTarget(targ, m_ALHeal);
         else
           targ.Cancel(m_Mobile, TargetCancelType.Canceled);

--- a/Scripts/Mobiles/AI/HealerAI.cs
+++ b/Scripts/Mobiles/AI/HealerAI.cs
@@ -2,7 +2,6 @@ using Server.Spells;
 using Server.Spells.First;
 using Server.Spells.Fourth;
 using Server.Spells.Second;
-using Server.Spells.Sixth;
 using Server.Targeting;
 
 namespace Server.Mobiles

--- a/Scripts/Mobiles/AI/MageAI.cs
+++ b/Scripts/Mobiles/AI/MageAI.cs
@@ -960,11 +960,13 @@ namespace Server.Mobiles
       if (targ == null)
         return false;
 
-      bool isReveal = targ is RevealSpell.InternalTarget;
-      bool isDispel = targ is DispelSpell.InternalTarget;
-      bool isParalyze = targ is ParalyzeSpell.InternalTarget;
-      bool isTeleport = targ is TeleportSpell.InternalTarget;
-      bool isInvisible = targ is InvisibilitySpell.InternalTarget;
+      ISpellTarget spellTarg = targ as ISpellTarget;
+
+      bool isReveal = spellTarg?.Spell is RevealSpell;
+      bool isDispel = spellTarg?.Spell is DispelSpell;
+      bool isParalyze = spellTarg?.Spell is ParalyzeSpell;
+      bool isTeleport = spellTarg?.Spell is TeleportSpell;
+      bool isInvisible = spellTarg?.Spell is InvisibilitySpell;
       bool teleportAway = false;
 
       Mobile toTarget;

--- a/Scripts/Mobiles/Monsters/AOS/Revenant.cs
+++ b/Scripts/Mobiles/Monsters/AOS/Revenant.cs
@@ -51,20 +51,8 @@ namespace Server.Mobiles
 
       VirtualArmor = 32;
 
-      Item shroud = new DeathShroud();
-
-      shroud.Hue = 0x455;
-
-      shroud.Movable = false;
-
-      AddItem(shroud);
-
-      Halberd weapon = new Halberd();
-
-      weapon.Hue = 1;
-      weapon.Movable = false;
-
-      AddItem(weapon);
+      AddItem(new DeathShroud { Hue = 0x455, Movable = false });
+      AddItem(new Halberd { Hue = 1, Movable = false });
     }
 
     public Revenant(Serial serial) : base(serial)

--- a/Scripts/Scripts.csproj
+++ b/Scripts/Scripts.csproj
@@ -3270,6 +3270,7 @@
     <Compile Include="Spells\Sixth\ParalyzeField.cs" />
     <Compile Include="Spells\Sixth\Reveal.cs" />
     <Compile Include="Spells\Targeting\IRecallSpell.cs" />
+    <Compile Include="Spells\Targeting\ISpellTarget.cs" />
     <Compile Include="Spells\Targeting\SpellTargetPoint3D.cs" />
     <Compile Include="Spells\Targeting\SpellTargetItem.cs" />
     <Compile Include="Spells\Targeting\SpellTargetMobile.cs" />

--- a/Scripts/Scripts.csproj
+++ b/Scripts/Scripts.csproj
@@ -3269,6 +3269,11 @@
     <Compile Include="Spells\Sixth\MassCurse.cs" />
     <Compile Include="Spells\Sixth\ParalyzeField.cs" />
     <Compile Include="Spells\Sixth\Reveal.cs" />
+    <Compile Include="Spells\Targeting\IRecallSpell.cs" />
+    <Compile Include="Spells\Targeting\SpellTargetPoint3D.cs" />
+    <Compile Include="Spells\Targeting\SpellTargetItem.cs" />
+    <Compile Include="Spells\Targeting\SpellTargetMobile.cs" />
+    <Compile Include="Spells\Targeting\RecallSpellTarget.cs" />
     <Compile Include="Spells\Spellweaving\ArcaneCircle.cs" />
     <Compile Include="Spells\Spellweaving\ArcaneForm.cs" />
     <Compile Include="Spells\Spellweaving\ArcaneSummon.cs" />

--- a/Scripts/Spells/Base/MagerySpell.cs
+++ b/Scripts/Spells/Base/MagerySpell.cs
@@ -20,13 +20,7 @@ namespace Server.Spells
 
     public override bool ConsumeReagents()
     {
-      if (base.ConsumeReagents())
-        return true;
-
-      if (ArcaneGem.ConsumeCharges(Caster, Core.SE ? 1 : 1 + (int)Circle))
-        return true;
-
-      return false;
+      return base.ConsumeReagents() || ArcaneGem.ConsumeCharges(Caster, Core.SE ? 1 : 1 + (int)Circle);
     }
 
     public override void GetCastSkills(out double min, out double max)
@@ -44,10 +38,7 @@ namespace Server.Spells
 
     public override int GetMana()
     {
-      if (Scroll is BaseWand)
-        return 0;
-
-      return m_ManaTable[(int)Circle];
+      return Scroll is BaseWand ? 0 : m_ManaTable[(int)Circle];
     }
 
     public override double GetResistSkill(Mobile m)

--- a/Scripts/Spells/Chivalry/CleanseByFire.cs
+++ b/Scripts/Spells/Chivalry/CleanseByFire.cs
@@ -41,10 +41,11 @@ namespace Server.Spells.Chivalry
 
     public void Target(Mobile m)
     {
+      if (m == null)
+        return;
+
       if (!m.Poisoned)
-      {
         Caster.SendLocalizedMessage(1060176); // That creature is not poisoned!
-      }
       else if (CheckBSequence(m))
       {
         SpellHelper.Turn(Caster, m);

--- a/Scripts/Spells/Chivalry/CleanseByFire.cs
+++ b/Scripts/Spells/Chivalry/CleanseByFire.cs
@@ -4,7 +4,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Chivalry
 {
-  public class CleanseByFireSpell : PaladinSpell
+  public class CleanseByFireSpell : PaladinSpell, ISpellTargetingMobile
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Cleanse By Fire", "Expor Flamus",
@@ -36,7 +36,7 @@ namespace Server.Spells.Chivalry
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetMobile(this, TargetFlags.Beneficial, Core.ML ? 10 : 12);
     }
 
     public void Target(Mobile m)
@@ -100,27 +100,6 @@ namespace Server.Spells.Chivalry
       }
 
       FinishSequence();
-    }
-
-    private class InternalTarget : Target
-    {
-      private CleanseByFireSpell m_Owner;
-
-      public InternalTarget(CleanseByFireSpell owner) : base(Core.ML ? 10 : 12, false, TargetFlags.Beneficial)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is Mobile mobile)
-          m_Owner.Target(mobile);
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
-      }
     }
   }
 }

--- a/Scripts/Spells/Chivalry/CloseWounds.cs
+++ b/Scripts/Spells/Chivalry/CloseWounds.cs
@@ -44,26 +44,19 @@ namespace Server.Spells.Chivalry
 
     public void Target(Mobile m)
     {
+      if (m == null)
+        return;
+
       if (!Caster.InRange(m, 2))
-      {
         Caster.SendLocalizedMessage(1060178); // You are too far away to perform that action!
-      }
       else if (m is BaseCreature creature && creature.IsAnimatedDead)
-      {
         Caster.SendLocalizedMessage(1061654); // You cannot heal that which is not alive.
-      }
       else if (m.IsDeadBondedPet)
-      {
         Caster.SendLocalizedMessage(1060177); // You cannot heal a creature that is already dead!
-      }
       else if (m.Hits >= m.HitsMax)
-      {
         Caster.SendLocalizedMessage(500955); // That being is not damaged!
-      }
       else if (m.Poisoned || MortalStrike.IsWounded(m))
-      {
         Caster.LocalOverheadMessage(MessageType.Regular, 0x3B2, Caster == m ? 1005000 : 1010398);
-      }
       else if (CheckBSequence(m))
       {
         SpellHelper.Turn(Caster, m);

--- a/Scripts/Spells/Chivalry/CloseWounds.cs
+++ b/Scripts/Spells/Chivalry/CloseWounds.cs
@@ -7,7 +7,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Chivalry
 {
-  public class CloseWoundsSpell : PaladinSpell
+  public class CloseWoundsSpell : PaladinSpell, ISpellTargetingMobile
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Close Wounds", "Obsu Vulni",
@@ -39,7 +39,7 @@ namespace Server.Spells.Chivalry
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetMobile(this, TargetFlags.Beneficial);
     }
 
     public void Target(Mobile m)
@@ -89,27 +89,6 @@ namespace Server.Spells.Chivalry
       }
 
       FinishSequence();
-    }
-
-    private class InternalTarget : Target
-    {
-      private CloseWoundsSpell m_Owner;
-
-      public InternalTarget(CloseWoundsSpell owner) : base(12, false, TargetFlags.Beneficial)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is Mobile mobile)
-          m_Owner.Target(mobile);
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
-      }
     }
   }
 }

--- a/Scripts/Spells/Chivalry/RemoveCurse.cs
+++ b/Scripts/Spells/Chivalry/RemoveCurse.cs
@@ -44,6 +44,9 @@ namespace Server.Spells.Chivalry
 
     public void Target(Mobile m)
     {
+      if (m == null)
+        return;
+
       if (CheckBSequence(m))
       {
         SpellHelper.Turn(Caster, m);
@@ -54,7 +57,7 @@ namespace Server.Spells.Chivalry
          * Chance of removing curse is affected by Caster's Karma.
          */
 
-        int chance = 0;
+        int chance;
 
         if (Caster.Karma < -5000)
           chance = 0;

--- a/Scripts/Spells/Chivalry/RemoveCurse.cs
+++ b/Scripts/Spells/Chivalry/RemoveCurse.cs
@@ -7,7 +7,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Chivalry
 {
-  public class RemoveCurseSpell : PaladinSpell
+  public class RemoveCurseSpell : PaladinSpell, ISpellTargetingMobile
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Remove Curse", "Extermo Vomica",
@@ -39,7 +39,7 @@ namespace Server.Spells.Chivalry
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetMobile(this, TargetFlags.Beneficial, Core.ML ? 10 : 12);
     }
 
     public void Target(Mobile m)
@@ -115,27 +115,6 @@ namespace Server.Spells.Chivalry
       }
 
       FinishSequence();
-    }
-
-    private class InternalTarget : Target
-    {
-      private RemoveCurseSpell m_Owner;
-
-      public InternalTarget(RemoveCurseSpell owner) : base(Core.ML ? 10 : 12, false, TargetFlags.Beneficial)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is Mobile mobile)
-          m_Owner.Target(mobile);
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
-      }
     }
   }
 }

--- a/Scripts/Spells/Chivalry/SacredJourney.cs
+++ b/Scripts/Spells/Chivalry/SacredJourney.cs
@@ -9,7 +9,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Chivalry
 {
-  public class SacredJourneySpell : PaladinSpell
+  public class SacredJourneySpell : PaladinSpell, IRecallSpell
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Sacred Journey", "Sanctum Viatas",
@@ -39,7 +39,7 @@ namespace Server.Spells.Chivalry
     public override void OnCast()
     {
       if (m_Entry == null)
-        Caster.Target = new InternalTarget(this);
+        Caster.Target = new RecallSpellTarget(this);
       else
         Effect(m_Entry.Location, m_Entry.Map, true);
     }
@@ -140,62 +140,6 @@ namespace Server.Spells.Chivalry
       }
 
       FinishSequence();
-    }
-
-    private class InternalTarget : Target
-    {
-      private SacredJourneySpell m_Owner;
-
-      public InternalTarget(SacredJourneySpell owner) : base(Core.ML ? 10 : 12, false, TargetFlags.None)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is RecallRune rune)
-        {
-          if (rune.Marked)
-            m_Owner.Effect(rune.Target, rune.TargetMap, true);
-          else
-            from.SendLocalizedMessage(501805); // That rune is not yet marked.
-        }
-        else if (o is Runebook runebook)
-        {
-          RunebookEntry e = runebook.Default;
-
-          if (e != null)
-            m_Owner.Effect(e.Location, e.Map, true);
-          else
-            from.SendLocalizedMessage(502354); // Target is not marked.
-        }
-        else if (o is Key key && key.KeyValue != 0 && key.Link is BaseBoat boat)
-        {
-          if (!boat.Deleted && boat.CheckKey(key.KeyValue))
-            m_Owner.Effect(boat.GetMarkedLocation(), boat.Map, false);
-          else
-            from.Send(new MessageLocalized(from.Serial, from.Body, MessageType.Regular, 0x3B2, 3, 502357,
-              from.Name, "")); // I can not recall from that object.
-        }
-        else if (o is HouseRaffleDeed deed && deed.ValidLocation())
-        {
-          m_Owner.Effect(deed.PlotLocation, deed.PlotFacet, true);
-        }
-        else
-        {
-          from.Send(new MessageLocalized(from.Serial, from.Body, MessageType.Regular, 0x3B2, 3, 502357, from.Name,
-            "")); // I can not recall from that object.
-        }
-      }
-
-      protected override void OnNonlocalTarget(Mobile from, object o)
-      {
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
-      }
     }
   }
 }

--- a/Scripts/Spells/Chivalry/SacredJourney.cs
+++ b/Scripts/Spells/Chivalry/SacredJourney.cs
@@ -3,9 +3,6 @@ using Server.Factions;
 using Server.Items;
 using Server.Misc;
 using Server.Mobiles;
-using Server.Multis;
-using Server.Network;
-using Server.Targeting;
 
 namespace Server.Spells.Chivalry
 {

--- a/Scripts/Spells/Eighth/EnergyVortex.cs
+++ b/Scripts/Spells/Eighth/EnergyVortex.cs
@@ -4,7 +4,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Eighth
 {
-  public class EnergyVortexSpell : MagerySpell
+  public class EnergyVortexSpell : MagerySpell, ISpellTargetingPoint3D
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Energy Vortex", "Vas Corp Por",
@@ -39,7 +39,7 @@ namespace Server.Spells.Eighth
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetPoint3D(this);
     }
 
     public void Target(IPoint3D p)
@@ -65,35 +65,6 @@ namespace Server.Spells.Eighth
       }
 
       FinishSequence();
-    }
-
-    private class InternalTarget : Target
-    {
-      private EnergyVortexSpell m_Owner;
-
-      public InternalTarget(EnergyVortexSpell owner) : base(Core.ML ? 10 : 12, true, TargetFlags.None)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is IPoint3D d)
-          m_Owner.Target(d);
-      }
-
-      protected override void OnTargetOutOfLOS(Mobile from, object o)
-      {
-        from.SendLocalizedMessage(501943); // Target cannot be seen. Try again.
-        from.Target = new InternalTarget(m_Owner);
-        from.Target.BeginTimeout(from, TimeoutTime - DateTime.UtcNow);
-        m_Owner = null;
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner?.FinishSequence();
-      }
     }
   }
 }

--- a/Scripts/Spells/Eighth/EnergyVortex.cs
+++ b/Scripts/Spells/Eighth/EnergyVortex.cs
@@ -1,6 +1,5 @@
 using System;
 using Server.Mobiles;
-using Server.Targeting;
 
 namespace Server.Spells.Eighth
 {

--- a/Scripts/Spells/Eighth/Resurrection.cs
+++ b/Scripts/Spells/Eighth/Resurrection.cs
@@ -4,7 +4,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Eighth
 {
-  public class ResurrectionSpell : MagerySpell
+  public class ResurrectionSpell : MagerySpell, ISpellTargetingMobile
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Resurrection", "An Corp",
@@ -34,7 +34,7 @@ namespace Server.Spells.Eighth
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetMobile(this, TargetFlags.Beneficial, 1);
     }
 
     public void Target(Mobile m)
@@ -85,27 +85,6 @@ namespace Server.Spells.Eighth
       }
 
       FinishSequence();
-    }
-
-    private class InternalTarget : Target
-    {
-      private ResurrectionSpell m_Owner;
-
-      public InternalTarget(ResurrectionSpell owner) : base(1, false, TargetFlags.Beneficial)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is Mobile mobile)
-          m_Owner.Target(mobile);
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
-      }
     }
   }
 }

--- a/Scripts/Spells/Eighth/Resurrection.cs
+++ b/Scripts/Spells/Eighth/Resurrection.cs
@@ -39,40 +39,29 @@ namespace Server.Spells.Eighth
 
     public void Target(Mobile m)
     {
+      if (m == null)
+        return;
+
       if (!Caster.CanSee(m))
-      {
         Caster.SendLocalizedMessage(500237); // Target can not be seen.
-      }
       else if (m == Caster)
-      {
         Caster.SendLocalizedMessage(501039); // Thou can not resurrect thyself.
-      }
       else if (!Caster.Alive)
-      {
         Caster.SendLocalizedMessage(501040); // The resurrecter must be alive.
-      }
       else if (m.Alive)
-      {
         Caster.SendLocalizedMessage(501041); // Target is not dead.
-      }
       else if (!Caster.InRange(m, 1))
-      {
         Caster.SendLocalizedMessage(501042); // Target is not close enough.
-      }
       else if (!m.Player)
-      {
         Caster.SendLocalizedMessage(501043); // Target is not a being.
-      }
       else if (m.Map == null || !m.Map.CanFit(m.Location, 16, false, false))
       {
         Caster.SendLocalizedMessage(501042); // Target can not be resurrected at that location.
         m.SendLocalizedMessage(502391); // Thou can not be resurrected there!
       }
       else if (m.Region?.IsPartOf("Khaldun") == true)
-      {
         Caster.SendLocalizedMessage(
           1010395); // The veil of death in this area is too strong and resists thy efforts to restore life.
-      }
       else if (CheckBSequence(m, true))
       {
         SpellHelper.Turn(Caster, m);

--- a/Scripts/Spells/Fifth/BladeSpirits.cs
+++ b/Scripts/Spells/Fifth/BladeSpirits.cs
@@ -1,6 +1,5 @@
 using System;
 using Server.Mobiles;
-using Server.Targeting;
 
 namespace Server.Spells.Fifth
 {

--- a/Scripts/Spells/Fifth/BladeSpirits.cs
+++ b/Scripts/Spells/Fifth/BladeSpirits.cs
@@ -4,7 +4,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Fifth
 {
-  public class BladeSpiritsSpell : MagerySpell
+  public class BladeSpiritsSpell : MagerySpell, ISpellTargetingPoint3D
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Blade Spirits", "In Jux Hur Ylem",
@@ -46,7 +46,7 @@ namespace Server.Spells.Fifth
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetPoint3D(this);
     }
 
     public void Target(IPoint3D p)
@@ -72,35 +72,6 @@ namespace Server.Spells.Fifth
       }
 
       FinishSequence();
-    }
-
-    private class InternalTarget : Target
-    {
-      private BladeSpiritsSpell m_Owner;
-
-      public InternalTarget(BladeSpiritsSpell owner) : base(Core.ML ? 10 : 12, true, TargetFlags.None)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is IPoint3D d)
-          m_Owner.Target(d);
-      }
-
-      protected override void OnTargetOutOfLOS(Mobile from, object o)
-      {
-        from.SendLocalizedMessage(501943); // Target cannot be seen. Try again.
-        from.Target = new InternalTarget(m_Owner);
-        from.Target.BeginTimeout(from, TimeoutTime - DateTime.UtcNow);
-        m_Owner = null;
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner?.FinishSequence();
-      }
     }
   }
 }

--- a/Scripts/Spells/Fifth/DispelField.cs
+++ b/Scripts/Spells/Fifth/DispelField.cs
@@ -1,4 +1,3 @@
-using System;
 using Server.Items;
 using Server.Misc;
 using Server.Targeting;

--- a/Scripts/Spells/Fifth/DispelField.cs
+++ b/Scripts/Spells/Fifth/DispelField.cs
@@ -5,7 +5,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Fifth
 {
-  public class DispelFieldSpell : MagerySpell
+  public class DispelFieldSpell : MagerySpell, ISpellTargetingItem
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Dispel Field", "An Grav",
@@ -25,25 +25,19 @@ namespace Server.Spells.Fifth
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetItem(this, TargetFlags.None, Core.ML ? 10 : 12);
     }
 
     public void Target(Item item)
     {
-      Type t = item.GetType();
-
-      if (!Caster.CanSee(item))
-      {
-        Caster.SendLocalizedMessage(500237); // Target can not be seen.
-      }
-      else if (!t.IsDefined(typeof(DispellableFieldAttribute), false))
-      {
+      if (item == null)
         Caster.SendLocalizedMessage(1005049); // That cannot be dispelled.
-      }
+      else if (!Caster.CanSee(item))
+        Caster.SendLocalizedMessage(500237); // Target can not be seen.
+      else if (!item.GetType().IsDefined(typeof(DispellableFieldAttribute), false))
+        Caster.SendLocalizedMessage(1005049); // That cannot be dispelled.
       else if (item is Moongate moongate && !moongate.Dispellable)
-      {
         Caster.SendLocalizedMessage(1005047); // That magic is too chaotic
-      }
       else if (CheckSequence())
       {
         SpellHelper.Turn(Caster, item);
@@ -56,29 +50,6 @@ namespace Server.Spells.Fifth
       }
 
       FinishSequence();
-    }
-
-    private class InternalTarget : Target
-    {
-      private DispelFieldSpell m_Owner;
-
-      public InternalTarget(DispelFieldSpell owner) : base(Core.ML ? 10 : 12, false, TargetFlags.None)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is Item item)
-          m_Owner.Target(item);
-        else
-          m_Owner.Caster.SendLocalizedMessage(1005049); // That cannot be dispelled.
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
-      }
     }
   }
 }

--- a/Scripts/Spells/Fifth/MagicReflect.cs
+++ b/Scripts/Spells/Fifth/MagicReflect.cs
@@ -132,16 +132,14 @@ namespace Server.Spells.Fifth
 
     public static void EndReflect(Mobile m)
     {
-      ResistanceMod[] mods = m_Table[m];
+      if (!m_Table.TryGetValue(m, out ResistanceMod[] mods))
+        return;
 
-      if (mods != null)
-      {
-        for (int i = 0; i < mods.Length; ++i)
-          m.RemoveResistanceMod(mods[i]);
+      for (int i = 0; i < mods?.Length; ++i)
+        m.RemoveResistanceMod(mods[i]);
 
-        m_Table.Remove(m);
-        BuffInfo.RemoveBuff(m, BuffIcon.MagicReflection);
-      }
+      m_Table.Remove(m);
+      BuffInfo.RemoveBuff(m, BuffIcon.MagicReflection);
     }
   }
 }

--- a/Scripts/Spells/Fifth/MindBlast.cs
+++ b/Scripts/Spells/Fifth/MindBlast.cs
@@ -3,7 +3,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Fifth
 {
-  public class MindBlastSpell : MagerySpell
+  public class MindBlastSpell : MagerySpell, ISpellTargetingMobile
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Mind Blast", "Por Corp Wis",
@@ -27,7 +27,7 @@ namespace Server.Spells.Fifth
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetMobile(this, TargetFlags.Harmful, Core.ML ? 10 : 12);
     }
 
     private void AosDelay_Callback(Mobile caster, Mobile target, Mobile defender, int damage)
@@ -121,27 +121,6 @@ namespace Server.Spells.Fifth
     public override double GetSlayerDamageScalar(Mobile target)
     {
       return 1.0; //This spell isn't affected by slayer spellbooks
-    }
-
-    private class InternalTarget : Target
-    {
-      private MindBlastSpell m_Owner;
-
-      public InternalTarget(MindBlastSpell owner) : base(Core.ML ? 10 : 12, false, TargetFlags.Harmful)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is Mobile mobile)
-          m_Owner.Target(mobile);
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
-      }
     }
   }
 }

--- a/Scripts/Spells/Fifth/MindBlast.cs
+++ b/Scripts/Spells/Fifth/MindBlast.cs
@@ -43,10 +43,11 @@ namespace Server.Spells.Fifth
 
     public void Target(Mobile m)
     {
+      if (m == null)
+        return;
+
       if (!Caster.CanSee(m))
-      {
         Caster.SendLocalizedMessage(500237); // Target can not be seen.
-      }
       else if (Core.AOS)
       {
         if (Caster.CanBeHarmful(m) && CheckSequence())

--- a/Scripts/Spells/Fifth/Paralyze.cs
+++ b/Scripts/Spells/Fifth/Paralyze.cs
@@ -5,7 +5,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Fifth
 {
-  public class ParalyzeSpell : MagerySpell
+  public class ParalyzeSpell : MagerySpell, ISpellTargetingMobile
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Paralyze", "An Ex Por",
@@ -24,7 +24,7 @@ namespace Server.Spells.Fifth
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetMobile(this, TargetFlags.Harmful, Core.ML ? 10 : 12);
     }
 
     public void Target(Mobile m)
@@ -86,27 +86,6 @@ namespace Server.Spells.Fifth
       }
 
       FinishSequence();
-    }
-
-    public class InternalTarget : Target
-    {
-      private ParalyzeSpell m_Owner;
-
-      public InternalTarget(ParalyzeSpell owner) : base(Core.ML ? 10 : 12, false, TargetFlags.Harmful)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is Mobile mobile)
-          m_Owner.Target(mobile);
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
-      }
     }
   }
 }

--- a/Scripts/Spells/Fifth/Paralyze.cs
+++ b/Scripts/Spells/Fifth/Paralyze.cs
@@ -29,10 +29,11 @@ namespace Server.Spells.Fifth
 
     public void Target(Mobile m)
     {
+      if (m == null)
+        return;
+
       if (!Caster.CanSee(m))
-      {
         Caster.SendLocalizedMessage(500237); // Target can not be seen.
-      }
       else if (Core.AOS && (m.Frozen || m.Paralyzed ||
                             m.Spell != null && m.Spell.IsCasting && !(m.Spell is PaladinSpell)))
       {

--- a/Scripts/Spells/Fifth/PoisonField.cs
+++ b/Scripts/Spells/Fifth/PoisonField.cs
@@ -8,7 +8,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Fifth
 {
-  public class PoisonFieldSpell : MagerySpell
+  public class PoisonFieldSpell : MagerySpell, ISpellTargetingPoint3D
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Poison Field", "In Nox Grav",
@@ -28,7 +28,7 @@ namespace Server.Spells.Fifth
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetPoint3D(this, TargetFlags.None, Core.ML ? 10 : 12, false);
     }
 
     public void Target(IPoint3D p)
@@ -268,27 +268,6 @@ namespace Server.Spells.Fifth
             }
           }
         }
-      }
-    }
-
-    private class InternalTarget : Target
-    {
-      private PoisonFieldSpell m_Owner;
-
-      public InternalTarget(PoisonFieldSpell owner) : base(Core.ML ? 10 : 12, true, TargetFlags.None)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is IPoint3D d)
-          m_Owner.Target(d);
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
       }
     }
   }

--- a/Scripts/Spells/Fifth/PoisonField.cs
+++ b/Scripts/Spells/Fifth/PoisonField.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using Server.Items;
 using Server.Misc;

--- a/Scripts/Spells/First/Clumsy.cs
+++ b/Scripts/Spells/First/Clumsy.cs
@@ -3,7 +3,7 @@ using Server.Targeting;
 
 namespace Server.Spells.First
 {
-  public class ClumsySpell : MagerySpell
+  public class ClumsySpell : MagerySpell, ISpellTargetingMobile
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Clumsy", "Uus Jux",
@@ -21,7 +21,7 @@ namespace Server.Spells.First
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetMobile(this, TargetFlags.Harmful, Core.ML ? 10 : 12);
     }
 
     public void Target(Mobile m)
@@ -54,27 +54,6 @@ namespace Server.Spells.First
       }
 
       FinishSequence();
-    }
-
-    private class InternalTarget : Target
-    {
-      private ClumsySpell m_Owner;
-
-      public InternalTarget(ClumsySpell owner) : base(Core.ML ? 10 : 12, false, TargetFlags.Harmful)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is Mobile mobile)
-          m_Owner.Target(mobile);
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
-      }
     }
   }
 }

--- a/Scripts/Spells/First/Clumsy.cs
+++ b/Scripts/Spells/First/Clumsy.cs
@@ -26,6 +26,9 @@ namespace Server.Spells.First
 
     public void Target(Mobile m)
     {
+      if (m == null)
+        return;
+
       if (!Caster.CanSee(m))
       {
         Caster.SendLocalizedMessage(500237); // Target can not be seen.

--- a/Scripts/Spells/First/Feeblemind.cs
+++ b/Scripts/Spells/First/Feeblemind.cs
@@ -26,10 +26,11 @@ namespace Server.Spells.First
 
     public void Target(Mobile m)
     {
+      if (m == null)
+        return;
+
       if (!Caster.CanSee(m))
-      {
         Caster.SendLocalizedMessage(500237); // Target can not be seen.
-      }
       else if (CheckHSequence(m))
       {
         SpellHelper.Turn(Caster, m);

--- a/Scripts/Spells/First/Feeblemind.cs
+++ b/Scripts/Spells/First/Feeblemind.cs
@@ -3,7 +3,7 @@ using Server.Targeting;
 
 namespace Server.Spells.First
 {
-  public class FeeblemindSpell : MagerySpell
+  public class FeeblemindSpell : MagerySpell, ISpellTargetingMobile
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Feeblemind", "Rel Wis",
@@ -21,7 +21,7 @@ namespace Server.Spells.First
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetMobile(this, TargetFlags.Harmful, Core.ML ? 10 : 12);
     }
 
     public void Target(Mobile m)
@@ -54,27 +54,6 @@ namespace Server.Spells.First
       }
 
       FinishSequence();
-    }
-
-    private class InternalTarget : Target
-    {
-      private FeeblemindSpell m_Owner;
-
-      public InternalTarget(FeeblemindSpell owner) : base(Core.ML ? 10 : 12, false, TargetFlags.Harmful)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is Mobile mobile)
-          m_Owner.Target(mobile);
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
-      }
     }
   }
 }

--- a/Scripts/Spells/First/Heal.cs
+++ b/Scripts/Spells/First/Heal.cs
@@ -41,6 +41,9 @@ namespace Server.Spells.First
 
     public void Target(Mobile m)
     {
+      if (m == null)
+        return;
+
       if (!Caster.CanSee(m))
       {
         Caster.SendLocalizedMessage(500237); // Target can not be seen.

--- a/Scripts/Spells/First/Heal.cs
+++ b/Scripts/Spells/First/Heal.cs
@@ -6,7 +6,7 @@ using Server.Targeting;
 
 namespace Server.Spells.First
 {
-  public class HealSpell : MagerySpell
+  public class HealSpell : MagerySpell, ISpellTargetingMobile
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Heal", "In Mani",
@@ -36,7 +36,7 @@ namespace Server.Spells.First
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetMobile(this, TargetFlags.Beneficial, Core.ML ? 10 : 12);
     }
 
     public void Target(Mobile m)
@@ -89,27 +89,6 @@ namespace Server.Spells.First
       }
 
       FinishSequence();
-    }
-
-    public class InternalTarget : Target
-    {
-      private HealSpell m_Owner;
-
-      public InternalTarget(HealSpell owner) : base(Core.ML ? 10 : 12, false, TargetFlags.Beneficial)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is Mobile mobile)
-          m_Owner.Target(mobile);
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
-      }
     }
   }
 }

--- a/Scripts/Spells/First/MagicArrow.cs
+++ b/Scripts/Spells/First/MagicArrow.cs
@@ -2,7 +2,7 @@ using Server.Targeting;
 
 namespace Server.Spells.First
 {
-  public class MagicArrowSpell : MagerySpell
+  public class MagicArrowSpell : MagerySpell, ISpellTargetingMobile
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Magic Arrow", "In Por Ylem",
@@ -23,7 +23,7 @@ namespace Server.Spells.First
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetMobile(this, TargetFlags.Harmful, Core.ML ? 10 : 12);
     }
 
     public void Target(Mobile m)
@@ -67,27 +67,6 @@ namespace Server.Spells.First
       }
 
       FinishSequence();
-    }
-
-    private class InternalTarget : Target
-    {
-      private MagicArrowSpell m_Owner;
-
-      public InternalTarget(MagicArrowSpell owner) : base(Core.ML ? 10 : 12, false, TargetFlags.Harmful)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is Mobile mobile)
-          m_Owner.Target(mobile);
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
-      }
     }
   }
 }

--- a/Scripts/Spells/First/MagicArrow.cs
+++ b/Scripts/Spells/First/MagicArrow.cs
@@ -28,10 +28,11 @@ namespace Server.Spells.First
 
     public void Target(Mobile m)
     {
+      if (m == null)
+        return;
+
       if (!Caster.CanSee(m))
-      {
         Caster.SendLocalizedMessage(500237); // Target can not be seen.
-      }
       else if (CheckHSequence(m))
       {
         Mobile source = Caster;

--- a/Scripts/Spells/First/ReactiveArmor.cs
+++ b/Scripts/Spells/First/ReactiveArmor.cs
@@ -138,16 +138,14 @@ namespace Server.Spells.First
 
     public static void EndArmor(Mobile m)
     {
-      ResistanceMod[] mods = m_Table[m];
+      if (!m_Table.TryGetValue(m, out ResistanceMod[] mods))
+        return;
 
-      if (mods != null)
-      {
-        for (int i = 0; i < mods.Length; ++i)
-          m.RemoveResistanceMod(mods[i]);
+      for (int i = 0; i < mods?.Length; ++i)
+        m.RemoveResistanceMod(mods[i]);
 
-        m_Table.Remove(m);
-        BuffInfo.RemoveBuff(m, BuffIcon.ReactiveArmor);
-      }
+      m_Table.Remove(m);
+      BuffInfo.RemoveBuff(m, BuffIcon.ReactiveArmor);
     }
   }
 }

--- a/Scripts/Spells/First/Weaken.cs
+++ b/Scripts/Spells/First/Weaken.cs
@@ -3,7 +3,7 @@ using Server.Targeting;
 
 namespace Server.Spells.First
 {
-  public class WeakenSpell : MagerySpell
+  public class WeakenSpell : MagerySpell, ISpellTargetingMobile
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Weaken", "Des Mani",
@@ -21,7 +21,7 @@ namespace Server.Spells.First
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetMobile(this, TargetFlags.Harmful, Core.ML ? 10 : 12);
     }
 
     public void Target(Mobile m)
@@ -54,27 +54,6 @@ namespace Server.Spells.First
       }
 
       FinishSequence();
-    }
-
-    public class InternalTarget : Target
-    {
-      private WeakenSpell m_Owner;
-
-      public InternalTarget(WeakenSpell owner) : base(Core.ML ? 10 : 12, false, TargetFlags.Harmful)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is Mobile mobile)
-          m_Owner.Target(mobile);
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
-      }
     }
   }
 }

--- a/Scripts/Spells/First/Weaken.cs
+++ b/Scripts/Spells/First/Weaken.cs
@@ -26,10 +26,11 @@ namespace Server.Spells.First
 
     public void Target(Mobile m)
     {
+      if (m == null)
+        return;
+
       if (!Caster.CanSee(m))
-      {
         Caster.SendLocalizedMessage(500237); // Target can not be seen.
-      }
       else if (CheckHSequence(m))
       {
         SpellHelper.Turn(Caster, m);

--- a/Scripts/Spells/Fourth/ArchCure.cs
+++ b/Scripts/Spells/Fourth/ArchCure.cs
@@ -6,7 +6,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Fourth
 {
-  public class ArchCureSpell : MagerySpell
+  public class ArchCureSpell : MagerySpell, ISpellTargetingPoint3D
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Arch Cure", "Vas An Nox",
@@ -28,7 +28,7 @@ namespace Server.Spells.Fourth
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetPoint3D(this, TargetFlags.None, Core.ML ? 10 : 12);
     }
 
     public void Target(IPoint3D p)
@@ -150,27 +150,6 @@ namespace Server.Spells.Fourth
     private static bool IsAllyTo(Mobile from, Mobile to)
     {
       return Notoriety.Compute(from, to) == Notoriety.Ally;
-    }
-
-    private class InternalTarget : Target
-    {
-      private ArchCureSpell m_Owner;
-
-      public InternalTarget(ArchCureSpell owner) : base(Core.ML ? 10 : 12, true, TargetFlags.None)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is IPoint3D p)
-          m_Owner.Target(p);
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
-      }
     }
   }
 }

--- a/Scripts/Spells/Fourth/ArchProtection.cs
+++ b/Scripts/Spells/Fourth/ArchProtection.cs
@@ -7,7 +7,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Fourth
 {
-  public class ArchProtectionSpell : MagerySpell
+  public class ArchProtectionSpell : MagerySpell, ISpellTargetingPoint3D
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Arch Protection", "Vas Uus Sanct",
@@ -29,7 +29,7 @@ namespace Server.Spells.Fourth
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetPoint3D(this, TargetFlags.None, Core.ML ? 10 : 12);
     }
 
     public void Target(IPoint3D p)
@@ -128,27 +128,6 @@ namespace Server.Spells.Fourth
       protected override void OnTick()
       {
         RemoveEntry(m_Owner);
-      }
-    }
-
-    private class InternalTarget : Target
-    {
-      private ArchProtectionSpell m_Owner;
-
-      public InternalTarget(ArchProtectionSpell owner) : base(Core.ML ? 10 : 12, true, TargetFlags.None)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is IPoint3D p)
-          m_Owner.Target(p);
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
       }
     }
   }

--- a/Scripts/Spells/Fourth/Curse.cs
+++ b/Scripts/Spells/Fourth/Curse.cs
@@ -4,7 +4,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Fourth
 {
-  public class CurseSpell : MagerySpell
+  public class CurseSpell : MagerySpell, ISpellTargetingMobile
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Curse", "Des Sanct",
@@ -25,7 +25,7 @@ namespace Server.Spells.Fourth
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetMobile(this, TargetFlags.Harmful, Core.ML ? 10 : 12);
     }
 
     public static void RemoveEffect(Mobile m)
@@ -85,27 +85,6 @@ namespace Server.Spells.Fourth
       }
 
       FinishSequence();
-    }
-
-    private class InternalTarget : Target
-    {
-      private CurseSpell m_Owner;
-
-      public InternalTarget(CurseSpell owner) : base(Core.ML ? 10 : 12, false, TargetFlags.Harmful)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is Mobile mobile)
-          m_Owner.Target(mobile);
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
-      }
     }
   }
 }

--- a/Scripts/Spells/Fourth/Curse.cs
+++ b/Scripts/Spells/Fourth/Curse.cs
@@ -42,10 +42,11 @@ namespace Server.Spells.Fourth
 
     public void Target(Mobile m)
     {
+      if (m == null)
+        return;
+
       if (!Caster.CanSee(m))
-      {
         Caster.SendLocalizedMessage(500237); // Target can not be seen.
-      }
       else if (CheckHSequence(m))
       {
         SpellHelper.Turn(Caster, m);

--- a/Scripts/Spells/Fourth/FireField.cs
+++ b/Scripts/Spells/Fourth/FireField.cs
@@ -7,7 +7,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Fourth
 {
-  public class FireFieldSpell : MagerySpell
+  public class FireFieldSpell : MagerySpell, ISpellTargetingPoint3D
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Fire Field", "In Flam Grav",
@@ -27,7 +27,7 @@ namespace Server.Spells.Fourth
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetPoint3D(this, TargetFlags.None, Core.ML ? 10 : 12);
     }
 
     public void Target(IPoint3D p)
@@ -274,27 +274,6 @@ namespace Server.Spells.Fourth
             }
           }
         }
-      }
-    }
-
-    private class InternalTarget : Target
-    {
-      private FireFieldSpell m_Owner;
-
-      public InternalTarget(FireFieldSpell owner) : base(Core.ML ? 10 : 12, true, TargetFlags.None)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is IPoint3D d)
-          m_Owner.Target(d);
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
       }
     }
   }

--- a/Scripts/Spells/Fourth/GreaterHeal.cs
+++ b/Scripts/Spells/Fourth/GreaterHeal.cs
@@ -6,7 +6,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Fourth
 {
-  public class GreaterHealSpell : MagerySpell
+  public class GreaterHealSpell : MagerySpell, ISpellTargetingMobile
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Greater Heal", "In Vas Mani",
@@ -37,7 +37,7 @@ namespace Server.Spells.Fourth
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetMobile(this, TargetFlags.Beneficial, Core.ML ? 10 : 12);
     }
 
     public void Target(Mobile m)
@@ -79,27 +79,6 @@ namespace Server.Spells.Fourth
       }
 
       FinishSequence();
-    }
-
-    public class InternalTarget : Target
-    {
-      private GreaterHealSpell m_Owner;
-
-      public InternalTarget(GreaterHealSpell owner) : base(Core.ML ? 10 : 12, false, TargetFlags.Beneficial)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is Mobile mobile)
-          m_Owner.Target(mobile);
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
-      }
     }
   }
 }

--- a/Scripts/Spells/Fourth/GreaterHeal.cs
+++ b/Scripts/Spells/Fourth/GreaterHeal.cs
@@ -42,10 +42,11 @@ namespace Server.Spells.Fourth
 
     public void Target(Mobile m)
     {
+      if (m == null)
+        return;
+
       if (!Caster.CanSee(m))
-      {
         Caster.SendLocalizedMessage(500237); // Target can not be seen.
-      }
       else if (m is BaseCreature creature && creature.IsAnimatedDead)
       {
         Caster.SendLocalizedMessage(1061654); // You cannot heal that which is not alive.

--- a/Scripts/Spells/Fourth/Lightning.cs
+++ b/Scripts/Spells/Fourth/Lightning.cs
@@ -27,10 +27,11 @@ namespace Server.Spells.Fourth
 
     public void Target(Mobile m)
     {
+      if (m == null)
+        return;
+
       if (!Caster.CanSee(m))
-      {
         Caster.SendLocalizedMessage(500237); // Target can not be seen.
-      }
       else if (CheckHSequence(m))
       {
         SpellHelper.Turn(Caster, m);

--- a/Scripts/Spells/Fourth/Lightning.cs
+++ b/Scripts/Spells/Fourth/Lightning.cs
@@ -2,7 +2,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Fourth
 {
-  public class LightningSpell : MagerySpell
+  public class LightningSpell : MagerySpell, ISpellTargetingMobile
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Lightning", "Por Ort Grav",
@@ -22,7 +22,7 @@ namespace Server.Spells.Fourth
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetMobile(this, TargetFlags.Harmful, Core.ML ? 10 : 12);
     }
 
     public void Target(Mobile m)
@@ -63,27 +63,6 @@ namespace Server.Spells.Fourth
       }
 
       FinishSequence();
-    }
-
-    private class InternalTarget : Target
-    {
-      private LightningSpell m_Owner;
-
-      public InternalTarget(LightningSpell owner) : base(Core.ML ? 10 : 12, false, TargetFlags.Harmful)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is Mobile mobile)
-          m_Owner.Target(mobile);
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
-      }
     }
   }
 }

--- a/Scripts/Spells/Fourth/ManaDrain.cs
+++ b/Scripts/Spells/Fourth/ManaDrain.cs
@@ -4,7 +4,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Fourth
 {
-  public class ManaDrainSpell : MagerySpell
+  public class ManaDrainSpell : MagerySpell, ISpellTargetingMobile
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Mana Drain", "Ort Rel",
@@ -25,7 +25,7 @@ namespace Server.Spells.Fourth
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetMobile(this, TargetFlags.Harmful, Core.ML ? 10 : 12);
     }
 
     private void AosDelay_Callback(Mobile m, int mana)
@@ -102,27 +102,6 @@ namespace Server.Spells.Fourth
     public override double GetResistPercent(Mobile target)
     {
       return 99.0;
-    }
-
-    private class InternalTarget : Target
-    {
-      private ManaDrainSpell m_Owner;
-
-      public InternalTarget(ManaDrainSpell owner) : base(Core.ML ? 10 : 12, false, TargetFlags.Harmful)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is Mobile mobile)
-          m_Owner.Target(mobile);
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
-      }
     }
   }
 }

--- a/Scripts/Spells/Fourth/ManaDrain.cs
+++ b/Scripts/Spells/Fourth/ManaDrain.cs
@@ -43,10 +43,11 @@ namespace Server.Spells.Fourth
 
     public void Target(Mobile m)
     {
+      if (m == null)
+        return;
+
       if (!Caster.CanSee(m))
-      {
         Caster.SendLocalizedMessage(500237); // Target can not be seen.
-      }
       else if (CheckHSequence(m))
       {
         SpellHelper.Turn(Caster, m);

--- a/Scripts/Spells/Fourth/Recall.cs
+++ b/Scripts/Spells/Fourth/Recall.cs
@@ -9,7 +9,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Fourth
 {
-  public class RecallSpell : MagerySpell
+  public class RecallSpell : MagerySpell, IRecallSpell
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Recall", "Kal Ort Por",
@@ -46,7 +46,7 @@ namespace Server.Spells.Fourth
     public override void OnCast()
     {
       if (m_Entry == null)
-        Caster.Target = new InternalTarget(this);
+        Caster.Target = new RecallSpellTarget(this);
       else
         Effect(m_Entry.Location, m_Entry.Map, true);
     }
@@ -141,64 +141,6 @@ namespace Server.Spells.Fourth
       }
 
       FinishSequence();
-    }
-
-    private class InternalTarget : Target
-    {
-      private RecallSpell m_Owner;
-
-      public InternalTarget(RecallSpell owner) : base(Core.ML ? 10 : 12, false, TargetFlags.None)
-      {
-        m_Owner = owner;
-
-        owner.Caster.LocalOverheadMessage(MessageType.Regular, 0x3B2, 501029); // Select Marked item.
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is RecallRune rune)
-        {
-          if (rune.Marked)
-            m_Owner.Effect(rune.Target, rune.TargetMap, true);
-          else
-            from.SendLocalizedMessage(501805); // That rune is not yet marked.
-        }
-        else if (o is Runebook runebook)
-        {
-          RunebookEntry e = runebook.Default;
-
-          if (e != null)
-            m_Owner.Effect(e.Location, e.Map, true);
-          else
-            from.SendLocalizedMessage(502354); // Target is not marked.
-        }
-        else if (o is Key key && key.KeyValue != 0 && key.Link is BaseBoat boat)
-        {
-          if (!boat.Deleted && boat.CheckKey(key.KeyValue))
-            m_Owner.Effect(boat.GetMarkedLocation(), boat.Map, false);
-          else
-            from.Send(new MessageLocalized(from.Serial, from.Body, MessageType.Regular, 0x3B2, 3, 502357,
-              from.Name, "")); // I can not recall from that object.
-        }
-        else if (o is HouseRaffleDeed deed && deed.ValidLocation())
-        {
-          m_Owner.Effect(deed.PlotLocation, deed.PlotFacet, true);
-        }
-        else
-        {
-          from.Send(new MessageLocalized(from.Serial, from.Body, MessageType.Regular, 0x3B2, 3, 502357, from.Name,
-            "")); // I can not recall from that object.
-        }
-      }
-
-      protected override void OnNonlocalTarget(Mobile from, object o)
-      {
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
-      }
     }
   }
 }

--- a/Scripts/Spells/Fourth/Recall.cs
+++ b/Scripts/Spells/Fourth/Recall.cs
@@ -2,10 +2,7 @@ using Server.Factions;
 using Server.Items;
 using Server.Misc;
 using Server.Mobiles;
-using Server.Multis;
-using Server.Network;
 using Server.Spells.Necromancy;
-using Server.Targeting;
 
 namespace Server.Spells.Fourth
 {

--- a/Scripts/Spells/Mysticism/AnimatedWeaponSpell.cs
+++ b/Scripts/Spells/Mysticism/AnimatedWeaponSpell.cs
@@ -4,7 +4,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Mysticism
 {
-  public class AnimatedWeaponSpell : MysticSpell
+  public class AnimatedWeaponSpell : MysticSpell, ISpellTargetingPoint3D
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Animated Weapon", "In Jux Por Ylem",
@@ -28,7 +28,7 @@ namespace Server.Spells.Mysticism
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetPoint3D(this);
     }
 
     public void Target(IPoint3D p)
@@ -62,28 +62,6 @@ namespace Server.Spells.Mysticism
       }
 
       FinishSequence();
-    }
-
-    public class InternalTarget : Target
-    {
-      private AnimatedWeaponSpell m_Owner;
-
-      public InternalTarget(AnimatedWeaponSpell owner)
-        : base(12, true, TargetFlags.None)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is IPoint3D d)
-          m_Owner.Target(d);
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
-      }
     }
   }
 }

--- a/Scripts/Spells/Mysticism/AnimatedWeaponSpell.cs
+++ b/Scripts/Spells/Mysticism/AnimatedWeaponSpell.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Server.Mobiles;
-using Server.Targeting;
 
 namespace Server.Spells.Mysticism
 {

--- a/Scripts/Spells/Mysticism/EagleStrikeSpell.cs
+++ b/Scripts/Spells/Mysticism/EagleStrikeSpell.cs
@@ -32,6 +32,9 @@ namespace Server.Spells.Mysticism
 
     public void Target(Mobile m)
     {
+      if (m == null)
+        return;
+
       if (CheckHSequence(m))
       {
         /* Conjures a magical eagle that assaults the Target with

--- a/Scripts/Spells/Mysticism/EagleStrikeSpell.cs
+++ b/Scripts/Spells/Mysticism/EagleStrikeSpell.cs
@@ -3,7 +3,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Mysticism
 {
-  public class EagleStrikeSpell : MysticSpell
+  public class EagleStrikeSpell : MysticSpell, ISpellTargetingMobile
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Eagle Strike", "Kal Por Xen",
@@ -27,7 +27,7 @@ namespace Server.Spells.Mysticism
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetMobile(this, TargetFlags.Harmful);
     }
 
     public void Target(Mobile m)
@@ -61,28 +61,6 @@ namespace Server.Spells.Mysticism
       SpellHelper.Damage(this, to, damage, 0, 0, 0, 0, 100);
 
       to.PlaySound(0x64D);
-    }
-
-    private class InternalTarget : Target
-    {
-      private EagleStrikeSpell m_Owner;
-
-      public InternalTarget(EagleStrikeSpell owner)
-        : base(12, false, TargetFlags.Harmful)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is Mobile mobile)
-          m_Owner.Target(mobile);
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
-      }
     }
   }
 }

--- a/Scripts/Spells/Mysticism/HailStormSpell.cs
+++ b/Scripts/Spells/Mysticism/HailStormSpell.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using Server.Network;
-using Server.Targeting;
 
 namespace Server.Spells.Mysticism
 {

--- a/Scripts/Spells/Mysticism/HailStormSpell.cs
+++ b/Scripts/Spells/Mysticism/HailStormSpell.cs
@@ -5,7 +5,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Mysticism
 {
-  public class HailStormSpell : MysticSpell
+  public class HailStormSpell : MysticSpell, ISpellTargetingPoint3D
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Hail Storm", "Kal Des Ylem",
@@ -29,7 +29,7 @@ namespace Server.Spells.Mysticism
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetPoint3D(this);
     }
 
     public void Target(IPoint3D p)
@@ -117,28 +117,6 @@ namespace Server.Spells.Mysticism
       Effects.SendPacket(p, map,
         new HuedEffect(EffectType.Moving, Serial.Zero, Serial.Zero, 0x36D4, orig, dest, 0, 0, false, false, 0x63,
           0x4));
-    }
-
-    private class InternalTarget : Target
-    {
-      private HailStormSpell m_Owner;
-
-      public InternalTarget(HailStormSpell owner)
-        : base(12, true, TargetFlags.None)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is IPoint3D p)
-          m_Owner.Target(p);
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
-      }
     }
   }
 }

--- a/Scripts/Spells/Mysticism/NetherCycloneSpell.cs
+++ b/Scripts/Spells/Mysticism/NetherCycloneSpell.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using Server.Network;
-using Server.Targeting;
 
 namespace Server.Spells.Mysticism
 {

--- a/Scripts/Spells/Mysticism/NetherCycloneSpell.cs
+++ b/Scripts/Spells/Mysticism/NetherCycloneSpell.cs
@@ -5,7 +5,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Mysticism
 {
-  public class NetherCycloneSpell : MysticSpell
+  public class NetherCycloneSpell : MysticSpell, ISpellTargetingPoint3D
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Nether Cyclone", "Grav Hur",
@@ -29,7 +29,7 @@ namespace Server.Spells.Mysticism
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetPoint3D(this);
     }
 
     public void Target(IPoint3D p)
@@ -126,28 +126,6 @@ namespace Server.Spells.Mysticism
       Effects.SendPacket(p, map,
         new HuedEffect(EffectType.Moving, Serial.Zero, Serial.Zero, 0x375A, orig, dest, 0, 0, false, false, 0x49A,
           0x4));
-    }
-
-    private class InternalTarget : Target
-    {
-      private NetherCycloneSpell m_Owner;
-
-      public InternalTarget(NetherCycloneSpell owner)
-        : base(12, true, TargetFlags.None)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is IPoint3D p)
-          m_Owner.Target(p);
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
-      }
     }
   }
 }

--- a/Scripts/Spells/Necromancy/AnimateDeadSpell.cs
+++ b/Scripts/Spells/Necromancy/AnimateDeadSpell.cs
@@ -8,7 +8,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Necromancy
 {
-  public class AnimateDeadSpell : NecromancerSpell
+  public class AnimateDeadSpell : NecromancerSpell, ISpellTargetingItem
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Animate Dead", "Uus Corp",
@@ -105,7 +105,7 @@ namespace Server.Spells.Necromancy
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetItem(this, TargetFlags.None, Core.ML ? 10 : 12);
       Caster.SendLocalizedMessage(1061083); // Animate what corpse?
     }
 
@@ -128,9 +128,9 @@ namespace Server.Spells.Necromancy
       return null;
     }
 
-    public void Target(object obj)
+    public void Target(Item item)
     {
-      MaabusCoffinComponent comp = obj as MaabusCoffinComponent;
+      MaabusCoffinComponent comp = item as MaabusCoffinComponent;
 
       if (comp?.Addon is MaabusCoffin addon)
       {
@@ -152,7 +152,7 @@ namespace Server.Spells.Necromancy
         return;
       }
 
-      if (!(obj is Corpse c))
+      if (!(item is Corpse c))
       {
         Caster.SendLocalizedMessage(1061084); // You cannot animate that.
       }
@@ -368,26 +368,6 @@ namespace Server.Spells.Necromancy
       {
         m_ToSummon = toSummon;
         m_Requirement = requirement;
-      }
-    }
-
-    private class InternalTarget : Target
-    {
-      private AnimateDeadSpell m_Owner;
-
-      public InternalTarget(AnimateDeadSpell owner) : base(Core.ML ? 10 : 12, false, TargetFlags.None)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        m_Owner.Target(o);
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
       }
     }
   }

--- a/Scripts/Spells/Necromancy/BloodOathSpell.cs
+++ b/Scripts/Spells/Necromancy/BloodOathSpell.cs
@@ -5,7 +5,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Necromancy
 {
-  public class BloodOathSpell : NecromancerSpell
+  public class BloodOathSpell : NecromancerSpell, ISpellTargetingMobile
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Blood Oath", "In Jux Mani Xen",
@@ -28,20 +28,18 @@ namespace Server.Spells.Necromancy
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetMobile(this, TargetFlags.Harmful, Core.ML ? 10 : 12);
     }
 
     public void Target(Mobile m)
     {
-      if (Caster == m || !(m is PlayerMobile || m is BaseCreature)
-      ) // only PlayerMobile and BaseCreature implement blood oath checking
-      {
+      if (m == null)
         Caster.SendLocalizedMessage(1060508); // You can't curse that.
-      }
+      // only PlayerMobile and BaseCreature implement blood oath checking
+      else if (Caster == m || !(m is PlayerMobile || m is BaseCreature))
+        Caster.SendLocalizedMessage(1060508); // You can't curse that.
       else if (m_OathTable.ContainsKey(Caster))
-      {
         Caster.SendLocalizedMessage(1061607); // You are already bonded in a Blood Oath.
-      }
       else if (m_OathTable.ContainsKey(m))
       {
         if (m.Player)
@@ -146,29 +144,6 @@ namespace Server.Spells.Necromancy
         BuffInfo.RemoveBuff(m_Target, BuffIcon.BloodOathCurse);
 
         m_Table.Remove(m_Caster);
-      }
-    }
-
-    private class InternalTarget : Target
-    {
-      private BloodOathSpell m_Owner;
-
-      public InternalTarget(BloodOathSpell owner) : base(Core.ML ? 10 : 12, false, TargetFlags.Harmful)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is Mobile mobile)
-          m_Owner.Target(mobile);
-        else
-          from.SendLocalizedMessage(1060508); // You can't curse that.
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
       }
     }
   }

--- a/Scripts/Spells/Necromancy/CorpseSkin.cs
+++ b/Scripts/Spells/Necromancy/CorpseSkin.cs
@@ -4,7 +4,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Necromancy
 {
-  public class CorpseSkinSpell : NecromancerSpell
+  public class CorpseSkinSpell : NecromancerSpell, ISpellTargetingMobile
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Corpse Skin", "In Agle Corp Ylem",
@@ -27,11 +27,14 @@ namespace Server.Spells.Necromancy
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetMobile(this, TargetFlags.Harmful, Core.ML ? 10 : 12);
     }
 
     public void Target(Mobile m)
     {
+      if (m == null)
+        return;
+
       if (CheckHSequence(m))
       {
         SpellHelper.Turn(Caster, m);
@@ -124,27 +127,6 @@ namespace Server.Spells.Necromancy
       {
         m_Mobile.SendLocalizedMessage(1061688); // Your skin returns to normal.
         DoExpire();
-      }
-    }
-
-    private class InternalTarget : Target
-    {
-      private CorpseSkinSpell m_Owner;
-
-      public InternalTarget(CorpseSkinSpell owner) : base(Core.ML ? 10 : 12, false, TargetFlags.Harmful)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is Mobile mobile)
-          m_Owner.Target(mobile);
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
       }
     }
   }

--- a/Scripts/Spells/Necromancy/CorpseSkin.cs
+++ b/Scripts/Spells/Necromancy/CorpseSkin.cs
@@ -92,13 +92,11 @@ namespace Server.Spells.Necromancy
 
     public static bool RemoveCurse(Mobile m)
     {
-      ExpireTimer t = m_Table[m];
-
-      if (t == null)
+      if (!m_Table.TryGetValue(m, out ExpireTimer t))
         return false;
 
       m.SendLocalizedMessage(1061688); // Your skin returns to normal.
-      t.DoExpire();
+      t?.DoExpire();
       return true;
     }
 

--- a/Scripts/Spells/Necromancy/EvilOmen.cs
+++ b/Scripts/Spells/Necromancy/EvilOmen.cs
@@ -5,7 +5,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Necromancy
 {
-  public class EvilOmenSpell : NecromancerSpell
+  public class EvilOmenSpell : NecromancerSpell, ISpellTargetingMobile
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Evil Omen", "Pas Tym An Sanct",
@@ -29,15 +29,13 @@ namespace Server.Spells.Necromancy
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetMobile(this, TargetFlags.Harmful, Core.ML ? 10 : 12);
     }
 
     public void Target(Mobile m)
     {
       if (!(m is BaseCreature || m is PlayerMobile))
-      {
         Caster.SendLocalizedMessage(1060508); // You can't curse that.
-      }
       else if (CheckHSequence(m))
       {
         SpellHelper.Turn(Caster, m);
@@ -101,30 +99,6 @@ namespace Server.Spells.Necromancy
       mod.Remove();
 
       return true;
-    }
-
-    private class InternalTarget : Target
-    {
-      private EvilOmenSpell m_Owner;
-
-      public InternalTarget(EvilOmenSpell owner)
-        : base(Core.ML ? 10 : 12, false, TargetFlags.Harmful)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is Mobile mobile)
-          m_Owner.Target(mobile);
-        else
-          from.SendLocalizedMessage(1060508); // You can't curse that.
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
-      }
     }
   }
 }

--- a/Scripts/Spells/Necromancy/EvilOmen.cs
+++ b/Scripts/Spells/Necromancy/EvilOmen.cs
@@ -66,7 +66,7 @@ namespace Server.Spells.Necromancy
 
         TimeSpan duration = TimeSpan.FromSeconds(Caster.Skills.SpiritSpeak.Value / 12 + 1.0);
 
-        Timer.DelayCall(duration, TryEndEffect_Callback, m);
+        Timer.DelayCall(duration, mob => TryEndEffect(mob), m);
 
         HarmfulSpell(m);
 
@@ -76,27 +76,13 @@ namespace Server.Spells.Necromancy
       FinishSequence();
     }
 
-    /*
-     * The naming here was confusing. Its a 1-off effect spell.
-     * So, we don't actually "checkeffect"; we endeffect with bool
-     * return to determine external behaviors.
-     *
-     * -refactored.
-     */
-    private static void TryEndEffect_Callback(Mobile m)
-    {
-      TryEndEffect(m);
-    }
-
     public static bool TryEndEffect(Mobile m)
     {
-      DefaultSkillMod mod = m_Table[m];
-
-      if (mod == null)
+      if (!m_Table.TryGetValue(m, out DefaultSkillMod mod))
         return false;
 
       m_Table.Remove(m);
-      mod.Remove();
+      mod?.Remove();
 
       return true;
     }

--- a/Scripts/Spells/Necromancy/MindRot.cs
+++ b/Scripts/Spells/Necromancy/MindRot.cs
@@ -4,7 +4,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Necromancy
 {
-  public class MindRotSpell : NecromancerSpell
+  public class MindRotSpell : NecromancerSpell, ISpellTargetingMobile
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Mind Rot", "Wis An Ben",
@@ -28,15 +28,15 @@ namespace Server.Spells.Necromancy
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetMobile(this, TargetFlags.Harmful, Core.ML ? 10 : 12);
     }
 
     public void Target(Mobile m)
     {
-      if (HasMindRotScalar(m))
-      {
+      if (m == null)
+        Caster.SendLocalizedMessage(1060508); // You can't curse that.
+      else if (HasMindRotScalar(m))
         Caster.SendLocalizedMessage(1005559); // This spell is already in effect.
-      }
       else if (CheckHSequence(m))
       {
         SpellHelper.Turn(Caster, m);
@@ -101,29 +101,6 @@ namespace Server.Spells.Necromancy
         BuffInfo.AddBuff(target, new BuffInfo(BuffIcon.Mindrot, 1075665, duration, target));
         tmpB.m_MRExpireTimer.Start();
         target.SendLocalizedMessage(1074384);
-      }
-    }
-
-    private class InternalTarget : Target
-    {
-      private MindRotSpell m_Owner;
-
-      public InternalTarget(MindRotSpell owner) : base(Core.ML ? 10 : 12, false, TargetFlags.Harmful)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is Mobile mobile)
-          m_Owner.Target(mobile);
-        else
-          from.SendLocalizedMessage(1060508); // You can't curse that.
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
       }
     }
   }

--- a/Scripts/Spells/Necromancy/PainSpike.cs
+++ b/Scripts/Spells/Necromancy/PainSpike.cs
@@ -5,7 +5,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Necromancy
 {
-  public class PainSpikeSpell : NecromancerSpell
+  public class PainSpikeSpell : NecromancerSpell, ISpellTargetingMobile
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Pain Spike", "In Sar",
@@ -30,11 +30,14 @@ namespace Server.Spells.Necromancy
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetMobile(this, TargetFlags.Harmful, Core.ML ? 10 : 12);
     }
 
     public void Target(Mobile m)
     {
+      if (m == null)
+        return;
+
       if (CheckHSequence(m))
       {
         SpellHelper.Turn(Caster, m);
@@ -106,27 +109,6 @@ namespace Server.Spells.Necromancy
           m_Mobile.Hits += m_ToRestore;
 
         BuffInfo.RemoveBuff(m_Mobile, BuffIcon.PainSpike);
-      }
-    }
-
-    private class InternalTarget : Target
-    {
-      private PainSpikeSpell m_Owner;
-
-      public InternalTarget(PainSpikeSpell owner) : base(Core.ML ? 10 : 12, false, TargetFlags.Harmful)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is Mobile mobile)
-          m_Owner.Target(mobile);
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
       }
     }
   }

--- a/Scripts/Spells/Necromancy/PoisonStrike.cs
+++ b/Scripts/Spells/Necromancy/PoisonStrike.cs
@@ -7,7 +7,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Necromancy
 {
-  public class PoisonStrikeSpell : NecromancerSpell
+  public class PoisonStrikeSpell : NecromancerSpell, ISpellTargetingMobile
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Poison Strike", "In Vas Nox",
@@ -30,11 +30,14 @@ namespace Server.Spells.Necromancy
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetMobile(this, TargetFlags.Harmful, Core.ML ? 10 : 12);
     }
 
     public void Target(Mobile m)
     {
+      if (m == null)
+        return;
+
       if (CheckHSequence(m))
       {
         SpellHelper.Turn(Caster, m);
@@ -91,28 +94,6 @@ namespace Server.Spells.Necromancy
       }
 
       FinishSequence();
-    }
-
-    private class InternalTarget : Target
-    {
-      private PoisonStrikeSpell m_Owner;
-
-      public InternalTarget(PoisonStrikeSpell owner)
-        : base(Core.ML ? 10 : 12, false, TargetFlags.Harmful)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is Mobile mobile)
-          m_Owner.Target(mobile);
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
-      }
     }
   }
 }

--- a/Scripts/Spells/Necromancy/Strangle.cs
+++ b/Scripts/Spells/Necromancy/Strangle.cs
@@ -4,7 +4,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Necromancy
 {
-  public class StrangleSpell : NecromancerSpell
+  public class StrangleSpell : NecromancerSpell, ISpellTargetingMobile
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Strangle", "In Bal Nox",
@@ -27,11 +27,14 @@ namespace Server.Spells.Necromancy
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetMobile(this, TargetFlags.Harmful, Core.ML ? 10 : 12);
     }
 
     public void Target(Mobile m)
     {
+      if (m == null)
+        return;
+
       if (CheckHSequence(m))
       {
         SpellHelper.Turn(Caster, m);
@@ -206,27 +209,6 @@ namespace Server.Spells.Necromancy
           ) // OSI: randomly revealed between first and third damage tick, guessing 60% chance
             m_Target.RevealingAction();
         }
-      }
-    }
-
-    private class InternalTarget : Target
-    {
-      private StrangleSpell m_Owner;
-
-      public InternalTarget(StrangleSpell owner) : base(Core.ML ? 10 : 12, false, TargetFlags.Harmful)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is Mobile mobile)
-          m_Owner.Target(mobile);
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
       }
     }
   }

--- a/Scripts/Spells/Necromancy/VengefulSpirit.cs
+++ b/Scripts/Spells/Necromancy/VengefulSpirit.cs
@@ -4,7 +4,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Necromancy
 {
-  public class VengefulSpiritSpell : NecromancerSpell
+  public class VengefulSpiritSpell : NecromancerSpell, ISpellTargetingMobile
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Vengeful Spirit", "Kal Xen Bal Beh",
@@ -26,7 +26,7 @@ namespace Server.Spells.Necromancy
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetMobile(this, TargetFlags.Harmful, Core.ML ? 10 : 12);
     }
 
     public override bool CheckCast()
@@ -45,10 +45,11 @@ namespace Server.Spells.Necromancy
 
     public void Target(Mobile m)
     {
+      if (m == null)
+        return;
+
       if (Caster == m)
-      {
         Caster.SendLocalizedMessage(1061832); // You cannot exact vengeance on yourself.
-      }
       else if (CheckHSequence(m))
       {
         SpellHelper.Turn(Caster, m);
@@ -69,27 +70,6 @@ namespace Server.Spells.Necromancy
       }
 
       FinishSequence();
-    }
-
-    private class InternalTarget : Target
-    {
-      private VengefulSpiritSpell m_Owner;
-
-      public InternalTarget(VengefulSpiritSpell owner) : base(Core.ML ? 10 : 12, false, TargetFlags.Harmful)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is Mobile mobile)
-          m_Owner.Target(mobile);
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
-      }
     }
   }
 }

--- a/Scripts/Spells/Ninjitsu/ShadowJump.cs
+++ b/Scripts/Spells/Ninjitsu/ShadowJump.cs
@@ -9,7 +9,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Ninjitsu
 {
-  public class Shadowjump : NinjaSpell
+  public class Shadowjump : NinjaSpell, ISpellTargetingPoint3D
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Shadowjump", null,
@@ -48,7 +48,7 @@ namespace Server.Spells.Ninjitsu
     public override void OnCast()
     {
       Caster.SendLocalizedMessage(1063088); // You prepare to perform a Shadowjump.
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetPoint3D(this, TargetFlags.None, 11);
     }
 
     public void Target(IPoint3D p)
@@ -109,27 +109,6 @@ namespace Server.Spells.Ninjitsu
       }
 
       FinishSequence();
-    }
-
-    public class InternalTarget : Target
-    {
-      private Shadowjump m_Owner;
-
-      public InternalTarget(Shadowjump owner) : base(11, true, TargetFlags.None)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is IPoint3D p)
-          m_Owner.Target(p);
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
-      }
     }
   }
 }

--- a/Scripts/Spells/Second/Agility.cs
+++ b/Scripts/Spells/Second/Agility.cs
@@ -4,7 +4,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Second
 {
-  public class AgilitySpell : MagerySpell
+  public class AgilitySpell : MagerySpell, ISpellTargetingMobile
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Agility", "Ex Uus",
@@ -33,15 +33,16 @@ namespace Server.Spells.Second
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetMobile(this, TargetFlags.Beneficial, Core.ML ? 10 : 12);
     }
 
     public void Target(Mobile m)
     {
+      if (m == null)
+        return;
+
       if (!Caster.CanSee(m))
-      {
         Caster.SendLocalizedMessage(500237); // Target can not be seen.
-      }
       else if (CheckBSequence(m))
       {
         SpellHelper.Turn(Caster, m);
@@ -58,27 +59,6 @@ namespace Server.Spells.Second
       }
 
       FinishSequence();
-    }
-
-    private class InternalTarget : Target
-    {
-      private AgilitySpell m_Owner;
-
-      public InternalTarget(AgilitySpell owner) : base(Core.ML ? 10 : 12, false, TargetFlags.Beneficial)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is Mobile mobile)
-          m_Owner.Target(mobile);
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
-      }
     }
   }
 }

--- a/Scripts/Spells/Second/Cunning.cs
+++ b/Scripts/Spells/Second/Cunning.cs
@@ -4,7 +4,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Second
 {
-  public class CunningSpell : MagerySpell
+  public class CunningSpell : MagerySpell, ISpellTargetingMobile
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Cunning", "Uus Wis",
@@ -33,15 +33,16 @@ namespace Server.Spells.Second
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetMobile(this, TargetFlags.Beneficial, Core.ML ? 10 : 12);
     }
 
     public void Target(Mobile m)
     {
+      if (m == null)
+        return;
+
       if (!Caster.CanSee(m))
-      {
         Caster.SendLocalizedMessage(500237); // Target can not be seen.
-      }
       else if (CheckBSequence(m))
       {
         SpellHelper.Turn(Caster, m);
@@ -58,27 +59,6 @@ namespace Server.Spells.Second
       }
 
       FinishSequence();
-    }
-
-    private class InternalTarget : Target
-    {
-      private CunningSpell m_Owner;
-
-      public InternalTarget(CunningSpell owner) : base(Core.ML ? 10 : 12, false, TargetFlags.Beneficial)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is Mobile mobile)
-          m_Owner.Target(mobile);
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
-      }
     }
   }
 }

--- a/Scripts/Spells/Second/Cure.cs
+++ b/Scripts/Spells/Second/Cure.cs
@@ -3,7 +3,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Second
 {
-  public class CureSpell : MagerySpell
+  public class CureSpell : MagerySpell, ISpellTargetingMobile
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Cure", "An Nox",
@@ -32,15 +32,16 @@ namespace Server.Spells.Second
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetMobile(this, TargetFlags.Beneficial, Core.ML ? 10 : 12);
     }
 
     public void Target(Mobile m)
     {
+      if (m == null)
+        return;
+
       if (!Caster.CanSee(m))
-      {
         Caster.SendLocalizedMessage(500237); // Target can not be seen.
-      }
       else if (CheckBSequence(m))
       {
         SpellHelper.Turn(Caster, m);
@@ -74,27 +75,6 @@ namespace Server.Spells.Second
       }
 
       FinishSequence();
-    }
-
-    public class InternalTarget : Target
-    {
-      private CureSpell m_Owner;
-
-      public InternalTarget(CureSpell owner) : base(Core.ML ? 10 : 12, false, TargetFlags.Beneficial)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is Mobile mobile)
-          m_Owner.Target(mobile);
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
-      }
     }
   }
 }

--- a/Scripts/Spells/Second/Harm.cs
+++ b/Scripts/Spells/Second/Harm.cs
@@ -2,7 +2,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Second
 {
-  public class HarmSpell : MagerySpell
+  public class HarmSpell : MagerySpell, ISpellTargetingMobile
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Harm", "An Mani",
@@ -22,7 +22,7 @@ namespace Server.Spells.Second
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetMobile(this, TargetFlags.Harmful, Core.ML ? 10 : 12);
     }
 
     public override double GetSlayerDamageScalar(Mobile target)
@@ -32,10 +32,11 @@ namespace Server.Spells.Second
 
     public void Target(Mobile m)
     {
+      if (m == null)
+        return;
+
       if (!Caster.CanSee(m))
-      {
         Caster.SendLocalizedMessage(500237); // Target can not be seen.
-      }
       else if (CheckHSequence(m))
       {
         SpellHelper.Turn(Caster, m);
@@ -82,27 +83,6 @@ namespace Server.Spells.Second
       }
 
       FinishSequence();
-    }
-
-    private class InternalTarget : Target
-    {
-      private HarmSpell m_Owner;
-
-      public InternalTarget(HarmSpell owner) : base(Core.ML ? 10 : 12, false, TargetFlags.Harmful)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is Mobile mobile)
-          m_Owner.Target(mobile);
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
-      }
     }
   }
 }

--- a/Scripts/Spells/Second/RemoveTrap.cs
+++ b/Scripts/Spells/Second/RemoveTrap.cs
@@ -3,7 +3,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Second
 {
-  public class RemoveTrapSpell : MagerySpell
+  public class RemoveTrapSpell : MagerySpell, ISpellTargetingItem
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Remove Trap", "An Jux",
@@ -21,17 +21,19 @@ namespace Server.Spells.Second
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
-      Caster.SendMessage("What do you wish to untrap?");
+      Caster.Target = new SpellTargetItem(this, TargetFlags.None, Core.ML ? 10 : 12);
+      Caster.SendMessage("What do you wish to untrap?"); // TODO: Localization?
     }
 
-    public void Target(TrappableContainer item)
+    public void Target(Item item)
     {
-      if (!Caster.CanSee(item))
+      if (!(item is TrappableContainer cont))
+        Caster.SendMessage("You can't disarm that"); // TODO: Localization?
+      else if (!Caster.CanSee(item))
       {
         Caster.SendLocalizedMessage(500237); // Target can not be seen.
       }
-      else if (item.TrapType != TrapType.None && item.TrapType != TrapType.MagicTrap)
+      else if (cont.TrapType != TrapType.None && cont.TrapType != TrapType.MagicTrap)
       {
         base.DoFizzle();
       }
@@ -45,35 +47,12 @@ namespace Server.Spells.Second
           5015);
         Effects.PlaySound(loc, item.Map, 0x1F0);
 
-        item.TrapType = TrapType.None;
-        item.TrapPower = 0;
-        item.TrapLevel = 0;
+        cont.TrapType = TrapType.None;
+        cont.TrapPower = 0;
+        cont.TrapLevel = 0;
       }
 
       FinishSequence();
-    }
-
-    private class InternalTarget : Target
-    {
-      private RemoveTrapSpell m_Owner;
-
-      public InternalTarget(RemoveTrapSpell owner) : base(Core.ML ? 10 : 12, false, TargetFlags.None)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is TrappableContainer container)
-          m_Owner.Target(container);
-        else
-          from.SendMessage("You can't disarm that");
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
-      }
     }
   }
 }

--- a/Scripts/Spells/Second/Strength.cs
+++ b/Scripts/Spells/Second/Strength.cs
@@ -4,7 +4,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Second
 {
-  public class StrengthSpell : MagerySpell
+  public class StrengthSpell : MagerySpell, ISpellTargetingMobile
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Strength", "Uus Mani",
@@ -33,15 +33,16 @@ namespace Server.Spells.Second
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetMobile(this, TargetFlags.Beneficial, Core.ML ? 10 : 12);
     }
 
     public void Target(Mobile m)
     {
+      if (m == null)
+        return;
+
       if (!Caster.CanSee(m))
-      {
         Caster.SendLocalizedMessage(500237); // Target can not be seen.
-      }
       else if (CheckBSequence(m))
       {
         SpellHelper.Turn(Caster, m);
@@ -58,27 +59,6 @@ namespace Server.Spells.Second
       }
 
       FinishSequence();
-    }
-
-    private class InternalTarget : Target
-    {
-      private StrengthSpell m_Owner;
-
-      public InternalTarget(StrengthSpell owner) : base(Core.ML ? 10 : 12, false, TargetFlags.Beneficial)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is Mobile mobile)
-          m_Owner.Target(mobile);
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
-      }
     }
   }
 }

--- a/Scripts/Spells/Seventh/ChainLightning.cs
+++ b/Scripts/Spells/Seventh/ChainLightning.cs
@@ -4,7 +4,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Seventh
 {
-  public class ChainLightningSpell : MagerySpell
+  public class ChainLightningSpell : MagerySpell, ISpellTargetingPoint3D
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Chain Lightning", "Vas Ort Grav",
@@ -27,7 +27,7 @@ namespace Server.Spells.Seventh
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetPoint3D(this, TargetFlags.None, Core.ML ? 10 : 12);
     }
 
     public void Target(IPoint3D p)
@@ -106,27 +106,6 @@ namespace Server.Spells.Seventh
       }
 
       FinishSequence();
-    }
-
-    private class InternalTarget : Target
-    {
-      private ChainLightningSpell m_Owner;
-
-      public InternalTarget(ChainLightningSpell owner) : base(Core.ML ? 10 : 12, true, TargetFlags.None)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is IPoint3D p)
-          m_Owner.Target(p);
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
-      }
     }
   }
 }

--- a/Scripts/Spells/Seventh/FlameStrike.cs
+++ b/Scripts/Spells/Seventh/FlameStrike.cs
@@ -2,7 +2,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Seventh
 {
-  public class FlameStrikeSpell : MagerySpell
+  public class FlameStrikeSpell : MagerySpell, ISpellTargetingMobile
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Flame Strike", "Kal Vas Flam",
@@ -22,15 +22,16 @@ namespace Server.Spells.Seventh
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetMobile(this, TargetFlags.Harmful, Core.ML ? 10 : 12);
     }
 
     public void Target(Mobile m)
     {
+      if (m == null)
+        return;
+
       if (!Caster.CanSee(m))
-      {
         Caster.SendLocalizedMessage(500237); // Target can not be seen.
-      }
       else if (CheckHSequence(m))
       {
         SpellHelper.Turn(Caster, m);
@@ -64,27 +65,6 @@ namespace Server.Spells.Seventh
       }
 
       FinishSequence();
-    }
-
-    private class InternalTarget : Target
-    {
-      private FlameStrikeSpell m_Owner;
-
-      public InternalTarget(FlameStrikeSpell owner) : base(Core.ML ? 10 : 12, false, TargetFlags.Harmful)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is Mobile mobile)
-          m_Owner.Target(mobile);
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
-      }
     }
   }
 }

--- a/Scripts/Spells/Seventh/GateTravel.cs
+++ b/Scripts/Spells/Seventh/GateTravel.cs
@@ -4,8 +4,6 @@ using Server.Factions;
 using Server.Items;
 using Server.Misc;
 using Server.Mobiles;
-using Server.Network;
-using Server.Targeting;
 
 namespace Server.Spells.Seventh
 {

--- a/Scripts/Spells/Seventh/GateTravel.cs
+++ b/Scripts/Spells/Seventh/GateTravel.cs
@@ -9,7 +9,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Seventh
 {
-  public class GateTravelSpell : MagerySpell
+  public class GateTravelSpell : MagerySpell, IRecallSpell
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Gate Travel", "Vas Rel Por",
@@ -32,7 +32,7 @@ namespace Server.Spells.Seventh
     public override void OnCast()
     {
       if (m_Entry == null)
-        Caster.Target = new InternalTarget(this);
+        Caster.Target = new RecallSpellTarget(this, false);
       else
         Effect(m_Entry.Location, m_Entry.Map, true);
     }
@@ -180,65 +180,6 @@ namespace Server.Spells.Seventh
         {
           m_Item.Delete();
         }
-      }
-    }
-
-    private class InternalTarget : Target
-    {
-      private GateTravelSpell m_Owner;
-
-      public InternalTarget(GateTravelSpell owner) : base(12, false, TargetFlags.None)
-      {
-        m_Owner = owner;
-
-        owner.Caster.LocalOverheadMessage(MessageType.Regular, 0x3B2, 501029); // Select Marked item.
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is RecallRune rune)
-        {
-          if (rune.Marked)
-            m_Owner.Effect(rune.Target, rune.TargetMap, true);
-          else
-            from.SendLocalizedMessage(501803); // That rune is not yet marked.
-        }
-        else if (o is Runebook runebook)
-        {
-          RunebookEntry e = runebook.Default;
-
-          if (e != null)
-            m_Owner.Effect(e.Location, e.Map, true);
-          else
-            from.SendLocalizedMessage(502354); // Target is not marked.
-        }
-        /*else if ( o is Key && ((Key)o).KeyValue != 0 && ((Key)o).Link is BaseBoat )
-        {
-          BaseBoat boat = ((Key)o).Link as BaseBoat;
-
-          if ( !boat.Deleted && boat.CheckKey( ((Key)o).KeyValue ) )
-            m_Owner.Effect( boat.GetMarkedLocation(), boat.Map, false );
-          else
-            from.Send( new MessageLocalized( from.Serial, from.Body, MessageType.Regular, 0x3B2, 3, 501030, from.Name, "" ) ); // I can not gate travel from that object.
-        }*/
-        else if (o is HouseRaffleDeed deed && deed.ValidLocation())
-        {
-          m_Owner.Effect(deed.PlotLocation, deed.PlotFacet, true);
-        }
-        else
-        {
-          from.Send(new MessageLocalized(from.Serial, from.Body, MessageType.Regular, 0x3B2, 3, 501030, from.Name,
-            "")); // I can not gate travel from that object.
-        }
-      }
-
-      protected override void OnNonlocalTarget(Mobile from, object o)
-      {
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
       }
     }
   }

--- a/Scripts/Spells/Seventh/ManaVampire.cs
+++ b/Scripts/Spells/Seventh/ManaVampire.cs
@@ -2,7 +2,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Seventh
 {
-  public class ManaVampireSpell : MagerySpell
+  public class ManaVampireSpell : MagerySpell, ISpellTargetingMobile
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Mana Vampire", "Ort Sanct",
@@ -22,15 +22,16 @@ namespace Server.Spells.Seventh
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetMobile(this, TargetFlags.Harmful, Core.ML ? 10 : 12);
     }
 
     public void Target(Mobile m)
     {
+      if (m == null)
+        return;
+
       if (!Caster.CanSee(m))
-      {
         Caster.SendLocalizedMessage(500237); // Target can not be seen.
-      }
       else if (CheckHSequence(m))
       {
         SpellHelper.Turn(Caster, m);
@@ -91,26 +92,6 @@ namespace Server.Spells.Seventh
     public override double GetResistPercent(Mobile target)
     {
       return 98.0;
-    }
-
-    private class InternalTarget : Target
-    {
-      private ManaVampireSpell m_Owner;
-
-      public InternalTarget(ManaVampireSpell owner) : base(Core.ML ? 10 : 12, false, TargetFlags.Harmful)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is Mobile mobile)m_Owner.Target(mobile);
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
-      }
     }
   }
 }

--- a/Scripts/Spells/Seventh/MassDispel.cs
+++ b/Scripts/Spells/Seventh/MassDispel.cs
@@ -77,4 +77,5 @@ namespace Server.Spells.Seventh
 
       FinishSequence();
     }
+  }
 }

--- a/Scripts/Spells/Seventh/MassDispel.cs
+++ b/Scripts/Spells/Seventh/MassDispel.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-using System.Linq;
 using Server.Items;
 using Server.Mobiles;
 using Server.Targeting;

--- a/Scripts/Spells/Seventh/MassDispel.cs
+++ b/Scripts/Spells/Seventh/MassDispel.cs
@@ -6,7 +6,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Seventh
 {
-  public class MassDispelSpell : MagerySpell
+  public class MassDispelSpell : MagerySpell, ISpellTargetingPoint3D
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Mass Dispel", "Vas An Ort",
@@ -26,7 +26,7 @@ namespace Server.Spells.Seventh
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetPoint3D(this, TargetFlags.None, Core.ML ? 10 : 12);
     }
 
     public void Target(IPoint3D p)
@@ -77,26 +77,4 @@ namespace Server.Spells.Seventh
 
       FinishSequence();
     }
-
-    private class InternalTarget : Target
-    {
-      private MassDispelSpell m_Owner;
-
-      public InternalTarget(MassDispelSpell owner) : base(Core.ML ? 10 : 12, true, TargetFlags.None)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is IPoint3D p)
-          m_Owner.Target(p);
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
-      }
-    }
-  }
 }

--- a/Scripts/Spells/Seventh/MeteorSwarm.cs
+++ b/Scripts/Spells/Seventh/MeteorSwarm.cs
@@ -4,7 +4,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Seventh
 {
-  public class MeteorSwarmSpell : MagerySpell
+  public class MeteorSwarmSpell : MagerySpell, ISpellTargetingPoint3D
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Meteor Swarm", "Flam Kal Des Ylem",
@@ -27,7 +27,7 @@ namespace Server.Spells.Seventh
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetPoint3D(this, TargetFlags.None, Core.ML ? 10 : 12);
     }
 
     public void Target(IPoint3D p)
@@ -109,27 +109,6 @@ namespace Server.Spells.Seventh
       }
 
       FinishSequence();
-    }
-
-    private class InternalTarget : Target
-    {
-      private MeteorSwarmSpell m_Owner;
-
-      public InternalTarget(MeteorSwarmSpell owner) : base(Core.ML ? 10 : 12, true, TargetFlags.None)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is IPoint3D p)
-          m_Owner.Target(p);
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
-      }
     }
   }
 }

--- a/Scripts/Spells/Seventh/Polymorph.cs
+++ b/Scripts/Spells/Seventh/Polymorph.cs
@@ -166,7 +166,7 @@ namespace Server.Spells.Seventh
       if (!m_Timers.TryGetValue(m, out InternalTimer timer))
         return;
 
-      timer.Stop();
+      timer?.Stop();
       m_Timers.Remove(m);
     }
 

--- a/Scripts/Spells/Sixth/Dispel.cs
+++ b/Scripts/Spells/Sixth/Dispel.cs
@@ -4,7 +4,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Sixth
 {
-  public class DispelSpell : MagerySpell
+  public class DispelSpell : MagerySpell, ISpellTargetingMobile
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Dispel", "An Ort",
@@ -23,60 +23,41 @@ namespace Server.Spells.Sixth
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetMobile(this, TargetFlags.Harmful, Core.ML ? 10 : 12);
     }
 
-    public class InternalTarget : Target
+    public void Target(Mobile m)
     {
-      private DispelSpell m_Owner;
+      if (m == null)
+        return;
 
-      public InternalTarget(DispelSpell owner) : base(Core.ML ? 10 : 12, false, TargetFlags.Harmful)
+      if (!Caster.CanSee(m))
+        Caster.SendLocalizedMessage(500237); // Target can not be seen.
+      else if (!(m is BaseCreature bc && bc.IsDispellable))
+        Caster.SendLocalizedMessage(1005049); // That cannot be dispelled.
+      else if (CheckHSequence(m))
       {
-        m_Owner = owner;
-      }
+        SpellHelper.Turn(Caster, m);
 
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is Mobile m)
+        double dispelChance =
+          (50.0 + 100 * (Caster.Skills.Magery.Value - bc.DispelDifficulty) / (bc.DispelFocus * 2)) / 100;
+
+        if (dispelChance > Utility.RandomDouble())
         {
-          BaseCreature bc = m as BaseCreature;
+          Effects.SendLocationParticles(EffectItem.Create(m.Location, m.Map, EffectItem.DefaultDuration),
+            0x3728, 8, 20, 5042);
+          Effects.PlaySound(m, m.Map, 0x201);
 
-          if (!from.CanSee(m))
-          {
-            from.SendLocalizedMessage(500237); // Target can not be seen.
-          }
-          else if (bc == null || !bc.IsDispellable)
-          {
-            from.SendLocalizedMessage(1005049); // That cannot be dispelled.
-          }
-          else if (m_Owner.CheckHSequence(m))
-          {
-            SpellHelper.Turn(from, m);
-
-            double dispelChance =
-              (50.0 + 100 * (from.Skills.Magery.Value - bc.DispelDifficulty) / (bc.DispelFocus * 2)) / 100;
-
-            if (dispelChance > Utility.RandomDouble())
-            {
-              Effects.SendLocationParticles(EffectItem.Create(m.Location, m.Map, EffectItem.DefaultDuration),
-                0x3728, 8, 20, 5042);
-              Effects.PlaySound(m, m.Map, 0x201);
-
-              m.Delete();
-            }
-            else
-            {
-              m.FixedEffect(0x3779, 10, 20);
-              from.SendLocalizedMessage(1010084); // The creature resisted the attempt to dispel it!
-            }
-          }
+          m.Delete();
+        }
+        else
+        {
+          m.FixedEffect(0x3779, 10, 20);
+          Caster.SendLocalizedMessage(1010084); // The creature resisted the attempt to dispel it!
         }
       }
 
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
-      }
+      FinishSequence();
     }
   }
 }

--- a/Scripts/Spells/Sixth/EnergyBolt.cs
+++ b/Scripts/Spells/Sixth/EnergyBolt.cs
@@ -27,10 +27,11 @@ namespace Server.Spells.Sixth
 
     public void Target(Mobile m)
     {
+      if (m == null)
+        return;
+
       if (!Caster.CanSee(m))
-      {
         Caster.SendLocalizedMessage(500237); // Target can not be seen.
-      }
       else if (CheckHSequence(m))
       {
         Mobile source = Caster;

--- a/Scripts/Spells/Sixth/EnergyBolt.cs
+++ b/Scripts/Spells/Sixth/EnergyBolt.cs
@@ -2,7 +2,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Sixth
 {
-  public class EnergyBoltSpell : MagerySpell
+  public class EnergyBoltSpell : MagerySpell, ISpellTargetingMobile
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Energy Bolt", "Corp Por",
@@ -22,7 +22,7 @@ namespace Server.Spells.Sixth
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetMobile(this, TargetFlags.Harmful, Core.ML ? 10 : 12);
     }
 
     public void Target(Mobile m)
@@ -70,27 +70,6 @@ namespace Server.Spells.Sixth
       }
 
       FinishSequence();
-    }
-
-    private class InternalTarget : Target
-    {
-      private EnergyBoltSpell m_Owner;
-
-      public InternalTarget(EnergyBoltSpell owner) : base(Core.ML ? 10 : 12, false, TargetFlags.Harmful)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is Mobile mobile)
-          m_Owner.Target(mobile);
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
-      }
     }
   }
 }

--- a/Scripts/Spells/Sixth/Explosion.cs
+++ b/Scripts/Spells/Sixth/Explosion.cs
@@ -31,6 +31,9 @@ namespace Server.Spells.Sixth
 
     public void Target(Mobile m)
     {
+      if (m == null)
+        return;
+
       if (!Caster.CanSee(m))
       {
         Caster.SendLocalizedMessage(500237); // Target can not be seen.

--- a/Scripts/Spells/Sixth/Explosion.cs
+++ b/Scripts/Spells/Sixth/Explosion.cs
@@ -3,7 +3,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Sixth
 {
-  public class ExplosionSpell : MagerySpell
+  public class ExplosionSpell : MagerySpell, ISpellTargetingMobile
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Explosion", "Vas Ort Flam",
@@ -26,7 +26,7 @@ namespace Server.Spells.Sixth
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetMobile(this, TargetFlags.Harmful, Core.ML ? 10 : 12);
     }
 
     public void Target(Mobile m)
@@ -103,28 +103,6 @@ namespace Server.Spells.Sixth
 
           m_Spell?.RemoveDelayedDamageContext(m_Attacker);
         }
-      }
-    }
-
-    private class InternalTarget : Target
-    {
-      private ExplosionSpell m_Owner;
-
-      public InternalTarget(ExplosionSpell owner)
-        : base(Core.ML ? 10 : 12, false, TargetFlags.Harmful)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is Mobile mobile)
-          m_Owner.Target(mobile);
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
       }
     }
   }

--- a/Scripts/Spells/Sixth/Invisibility.cs
+++ b/Scripts/Spells/Sixth/Invisibility.cs
@@ -7,7 +7,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Sixth
 {
-  public class InvisibilitySpell : MagerySpell
+  public class InvisibilitySpell : MagerySpell, ISpellTargetingMobile
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Invisibility", "An Lor Xen",
@@ -38,7 +38,7 @@ namespace Server.Spells.Sixth
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetMobile(this, TargetFlags.Beneficial, Core.ML ? 10 : 12);
     }
 
     public void Target(Mobile m)
@@ -112,27 +112,6 @@ namespace Server.Spells.Sixth
       {
         m_Mobile.RevealingAction();
         RemoveTimer(m_Mobile);
-      }
-    }
-
-    public class InternalTarget : Target
-    {
-      private InvisibilitySpell m_Owner;
-
-      public InternalTarget(InvisibilitySpell owner) : base(Core.ML ? 10 : 12, false, TargetFlags.Beneficial)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is Mobile mobile)
-          m_Owner.Target(mobile);
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
       }
     }
   }

--- a/Scripts/Spells/Sixth/Invisibility.cs
+++ b/Scripts/Spells/Sixth/Invisibility.cs
@@ -43,6 +43,9 @@ namespace Server.Spells.Sixth
 
     public void Target(Mobile m)
     {
+      if (m == null)
+        return;
+
       if (!Caster.CanSee(m))
       {
         Caster.SendLocalizedMessage(500237); // Target can not be seen.

--- a/Scripts/Spells/Sixth/MassCurse.cs
+++ b/Scripts/Spells/Sixth/MassCurse.cs
@@ -4,7 +4,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Sixth
 {
-  public class MassCurseSpell : MagerySpell
+  public class MassCurseSpell : MagerySpell, ISpellTargetingPoint3D
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Mass Curse", "Vas Des Sanct",
@@ -25,7 +25,7 @@ namespace Server.Spells.Sixth
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetPoint3D(this, TargetFlags.None, Core.ML ? 10 : 12);
     }
 
     public void Target(IPoint3D p)
@@ -71,27 +71,6 @@ namespace Server.Spells.Sixth
       }
 
       FinishSequence();
-    }
-
-    private class InternalTarget : Target
-    {
-      private MassCurseSpell m_Owner;
-
-      public InternalTarget(MassCurseSpell owner) : base(Core.ML ? 10 : 12, true, TargetFlags.None)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is IPoint3D p)
-          m_Owner.Target(p);
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
-      }
     }
   }
 }

--- a/Scripts/Spells/Sixth/MassCurse.cs
+++ b/Scripts/Spells/Sixth/MassCurse.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-using System.Linq;
 using Server.Targeting;
 
 namespace Server.Spells.Sixth

--- a/Scripts/Spells/Sixth/ParalyzeField.cs
+++ b/Scripts/Spells/Sixth/ParalyzeField.cs
@@ -6,7 +6,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Sixth
 {
-  public class ParalyzeFieldSpell : MagerySpell
+  public class ParalyzeFieldSpell : MagerySpell, ISpellTargetingPoint3D
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Paralyze Field", "In Ex Grav",
@@ -26,7 +26,7 @@ namespace Server.Spells.Sixth
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetPoint3D(this, TargetFlags.None, Core.ML ? 10 : 12);
     }
 
     public void Target(IPoint3D p)
@@ -66,9 +66,8 @@ namespace Server.Spells.Sixth
         for (int i = -2; i <= 2; ++i)
         {
           Point3D loc = new Point3D(eastToWest ? p.X + i : p.X, eastToWest ? p.Y : p.Y + i, p.Z);
-          bool canFit = SpellHelper.AdjustField(ref loc, Caster.Map, 12, false);
 
-          if (!canFit)
+          if (!SpellHelper.AdjustField(ref loc, Caster.Map, 12, false))
             continue;
 
           Item item = new InternalItem(Caster, itemID, loc, Caster.Map, duration);
@@ -210,27 +209,6 @@ namespace Server.Spells.Sixth
         {
           m_Item.Delete();
         }
-      }
-    }
-
-    private class InternalTarget : Target
-    {
-      private ParalyzeFieldSpell m_Owner;
-
-      public InternalTarget(ParalyzeFieldSpell owner) : base(Core.ML ? 10 : 12, true, TargetFlags.None)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is IPoint3D d)
-          m_Owner.Target(d);
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
       }
     }
   }

--- a/Scripts/Spells/Sixth/Reveal.cs
+++ b/Scripts/Spells/Sixth/Reveal.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-using System.Linq;
 using Server.Mobiles;
 using Server.Targeting;
 

--- a/Scripts/Spells/Sixth/Reveal.cs
+++ b/Scripts/Spells/Sixth/Reveal.cs
@@ -5,7 +5,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Sixth
 {
-  public class RevealSpell : MagerySpell
+  public class RevealSpell : MagerySpell, ISpellTargetingPoint3D
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Reveal", "Wis Quas",
@@ -23,7 +23,7 @@ namespace Server.Spells.Sixth
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetPoint3D(this, TargetFlags.None, Core.ML ? 10 : 12);
     }
 
     public void Target(IPoint3D p)
@@ -85,27 +85,6 @@ namespace Server.Spells.Sixth
         chance = 100;
 
       return chance > Utility.Random(100);
-    }
-
-    public class InternalTarget : Target
-    {
-      private RevealSpell m_Owner;
-
-      public InternalTarget(RevealSpell owner) : base(Core.ML ? 10 : 12, true, TargetFlags.None)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is IPoint3D p)
-          m_Owner.Target(p);
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
-      }
     }
   }
 }

--- a/Scripts/Spells/Spellweaving/EssenceOfWind.cs
+++ b/Scripts/Spells/Spellweaving/EssenceOfWind.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Server.Spells.Spellweaving
 {

--- a/Scripts/Spells/Spellweaving/GiftOfRenewal.cs
+++ b/Scripts/Spells/Spellweaving/GiftOfRenewal.cs
@@ -4,7 +4,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Spellweaving
 {
-  public class GiftOfRenewalSpell : ArcanistSpell
+  public class GiftOfRenewalSpell : ArcanistSpell, ISpellTargetingMobile
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Gift of Renewal", "Olorisstra",
@@ -25,20 +25,20 @@ namespace Server.Spells.Spellweaving
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetMobile(this, TargetFlags.Beneficial, 10);
     }
 
     public void Target(Mobile m)
     {
-      if (!Caster.CanSee(m)) Caster.SendLocalizedMessage(500237); // Target can not be seen.
-      if (m_Table.ContainsKey(m))
-      {
+      if (m == null)
+        return;
+
+      if (!Caster.CanSee(m))
+        Caster.SendLocalizedMessage(500237); // Target can not be seen.
+      else if (m_Table.ContainsKey(m))
         Caster.SendLocalizedMessage(501775); // This spell is already in effect.
-      }
       else if (!Caster.CanBeginAction<GiftOfRenewalSpell>())
-      {
         Caster.SendLocalizedMessage(501789); // You must wait before trying again.
-      }
       else if (CheckBSequence(m))
       {
         SpellHelper.Turn(Caster, m);
@@ -149,28 +149,6 @@ namespace Server.Spells.Spellweaving
 
         SpellHelper.Heal(toHeal, m, m_GiftInfo.m_Caster);
         m.FixedParticles(0x376A, 9, 32, 5005, EffectLayer.Waist);
-      }
-    }
-
-    private class InternalTarget : Target
-    {
-      private GiftOfRenewalSpell m_Owner;
-
-      public InternalTarget(GiftOfRenewalSpell owner)
-        : base(10, false, TargetFlags.Beneficial)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile m, object o)
-      {
-        if (o is Mobile mobile)
-          m_Owner.Target(mobile);
-      }
-
-      protected override void OnTargetFinish(Mobile m)
-      {
-        m_Owner.FinishSequence();
       }
     }
   }

--- a/Scripts/Spells/Spellweaving/NatureFury.cs
+++ b/Scripts/Spells/Spellweaving/NatureFury.cs
@@ -5,7 +5,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Spellweaving
 {
-  public class NatureFurySpell : ArcanistSpell
+  public class NatureFurySpell : ArcanistSpell, ISpellTargetingPoint3D
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Nature's Fury", "Rauvvrae",
@@ -39,7 +39,7 @@ namespace Server.Spells.Spellweaving
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetPoint3D(this, TargetFlags.None, 10);
     }
 
     public void Target(IPoint3D point)
@@ -68,28 +68,6 @@ namespace Server.Spells.Spellweaving
       }
 
       FinishSequence();
-    }
-
-    private class InternalTarget : Target
-    {
-      private NatureFurySpell m_Owner;
-
-      public InternalTarget(NatureFurySpell owner)
-        : base(10, true, TargetFlags.None)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is IPoint3D d)
-          m_Owner.Target(d);
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner?.FinishSequence();
-      }
     }
 
     private class InternalTimer : Timer

--- a/Scripts/Spells/Spellweaving/Thunderstorm.cs
+++ b/Scripts/Spells/Spellweaving/Thunderstorm.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Server.Spells.Spellweaving
 {

--- a/Scripts/Spells/Spellweaving/WordOfDeath.cs
+++ b/Scripts/Spells/Spellweaving/WordOfDeath.cs
@@ -3,7 +3,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Spellweaving
 {
-  public class WordOfDeathSpell : ArcanistSpell
+  public class WordOfDeathSpell : ArcanistSpell, ISpellTargetingMobile
   {
     private static SpellInfo m_Info = new SpellInfo("Word of Death", "Nyraxle", -1);
 
@@ -18,15 +18,16 @@ namespace Server.Spells.Spellweaving
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetMobile(this, TargetFlags.Harmful, 10);
     }
 
     public void Target(Mobile m)
     {
+      if (m == null)
+        return;
+
       if (!Caster.CanSee(m))
-      {
         Caster.SendLocalizedMessage(500237); // Target can not be seen.
-      }
       else if (CheckHSequence(m))
       {
         Point3D loc = m.Location;
@@ -62,27 +63,6 @@ namespace Server.Spells.Spellweaving
       }
 
       FinishSequence();
-    }
-
-    public class InternalTarget : Target
-    {
-      private WordOfDeathSpell m_Owner;
-
-      public InternalTarget(WordOfDeathSpell owner) : base(10, false, TargetFlags.Harmful)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile m, object o)
-      {
-        if (o is Mobile mobile)
-          m_Owner.Target(mobile);
-      }
-
-      protected override void OnTargetFinish(Mobile m)
-      {
-        m_Owner.FinishSequence();
-      }
     }
   }
 }

--- a/Scripts/Spells/Targeting/IRecallSpell.cs
+++ b/Scripts/Spells/Targeting/IRecallSpell.cs
@@ -1,0 +1,9 @@
+namespace Server.Spells
+{
+  public interface IRecallSpell
+  {
+    Mobile Caster{ get; }
+    void Effect(Point3D loc, Map map, bool checkMulti);
+    void FinishSequence();
+  }
+}

--- a/Scripts/Spells/Targeting/ISpellTarget.cs
+++ b/Scripts/Spells/Targeting/ISpellTarget.cs
@@ -1,0 +1,7 @@
+namespace Server.Spells
+{
+  public interface ISpellTarget
+  {
+    ISpell Spell{ get; }
+  }
+}

--- a/Scripts/Spells/Targeting/RecallSpellTarget.cs
+++ b/Scripts/Spells/Targeting/RecallSpellTarget.cs
@@ -8,11 +8,12 @@ namespace Server.Spells
   public class RecallSpellTarget : Target
   {
     private IRecallSpell m_Spell;
+    private bool m_ToBoat;
 
-    public RecallSpellTarget(IRecallSpell spell) : base(Core.ML ? 10 : 12, false, TargetFlags.None)
+    public RecallSpellTarget(IRecallSpell spell, bool toBoat = true) : base(Core.ML ? 10 : 12, false, TargetFlags.None)
     {
       m_Spell = spell;
-
+      m_ToBoat = toBoat;
       m_Spell.Caster.LocalOverheadMessage(MessageType.Regular, 0x3B2, 501029); // Select Marked item.
     }
 
@@ -34,7 +35,7 @@ namespace Server.Spells
         else
           from.SendLocalizedMessage(502354); // Target is not marked.
       }
-      else if (o is Key key && key.KeyValue != 0 && key.Link is BaseBoat boat)
+      else if (m_ToBoat && o is Key key && key.KeyValue != 0 && key.Link is BaseBoat boat)
       {
         if (!boat.Deleted && boat.CheckKey(key.KeyValue))
           m_Spell.Effect(boat.GetMarkedLocation(), boat.Map, false);

--- a/Scripts/Spells/Targeting/RecallSpellTarget.cs
+++ b/Scripts/Spells/Targeting/RecallSpellTarget.cs
@@ -1,0 +1,65 @@
+using Server.Items;
+using Server.Multis;
+using Server.Network;
+using Server.Targeting;
+
+namespace Server.Spells
+{
+  public class RecallSpellTarget : Target
+  {
+    private IRecallSpell m_Spell;
+
+    public RecallSpellTarget(IRecallSpell spell) : base(Core.ML ? 10 : 12, false, TargetFlags.None)
+    {
+      m_Spell = spell;
+
+      m_Spell.Caster.LocalOverheadMessage(MessageType.Regular, 0x3B2, 501029); // Select Marked item.
+    }
+
+    protected override void OnTarget(Mobile from, object o)
+    {
+      if (o is RecallRune rune)
+      {
+        if (rune.Marked)
+          m_Spell.Effect(rune.Target, rune.TargetMap, true);
+        else
+          from.SendLocalizedMessage(501805); // That rune is not yet marked.
+      }
+      else if (o is Runebook runebook)
+      {
+        RunebookEntry e = runebook.Default;
+
+        if (e != null)
+          m_Spell.Effect(e.Location, e.Map, true);
+        else
+          from.SendLocalizedMessage(502354); // Target is not marked.
+      }
+      else if (o is Key key && key.KeyValue != 0 && key.Link is BaseBoat boat)
+      {
+        if (!boat.Deleted && boat.CheckKey(key.KeyValue))
+          m_Spell.Effect(boat.GetMarkedLocation(), boat.Map, false);
+        else
+          from.Send(new MessageLocalized(from.Serial, from.Body, MessageType.Regular, 0x3B2, 3, 502357,
+            from.Name, "")); // I can not recall from that object.
+      }
+      else if (o is HouseRaffleDeed deed && deed.ValidLocation())
+      {
+        m_Spell.Effect(deed.PlotLocation, deed.PlotFacet, true);
+      }
+      else
+      {
+        from.Send(new MessageLocalized(from.Serial, from.Body, MessageType.Regular, 0x3B2, 3, 502357, from.Name,
+          "")); // I can not recall from that object.
+      }
+    }
+
+    protected override void OnNonlocalTarget(Mobile from, object o)
+    {
+    }
+
+    protected override void OnTargetFinish(Mobile from)
+    {
+      m_Spell?.FinishSequence();
+    }
+  }
+}

--- a/Scripts/Spells/Targeting/SpellTargetItem.cs
+++ b/Scripts/Spells/Targeting/SpellTargetItem.cs
@@ -1,0 +1,30 @@
+using Server.Targeting;
+
+namespace Server.Spells
+{
+  public interface ISpellTargetingItem : ISpell
+  {
+    void Target(Item item);
+  }
+
+  public class SpellTargetItem : Target
+  {
+    public ISpellTargetingItem Spell{ get; }
+
+    public SpellTargetItem(ISpellTargetingItem spell, TargetFlags flags, int range = 12) : base(range, false, flags)
+    {
+      Spell = spell;
+    }
+
+    protected override void OnTarget(Mobile from, object o)
+    {
+      if (o is Item item)
+        Spell.Target(item);
+    }
+
+    protected override void OnTargetFinish(Mobile from)
+    {
+      Spell?.FinishSequence();
+    }
+  }
+}

--- a/Scripts/Spells/Targeting/SpellTargetItem.cs
+++ b/Scripts/Spells/Targeting/SpellTargetItem.cs
@@ -7,24 +7,25 @@ namespace Server.Spells
     void Target(Item item);
   }
 
-  public class SpellTargetItem : Target
+  public class SpellTargetItem : Target, ISpellTarget
   {
-    public ISpellTargetingItem Spell{ get; }
+    private ISpellTargetingItem m_Spell;
+    public ISpell Spell => m_Spell;
 
     public SpellTargetItem(ISpellTargetingItem spell, TargetFlags flags, int range = 12) : base(range, false, flags)
     {
-      Spell = spell;
+      m_Spell = spell;
     }
 
     protected override void OnTarget(Mobile from, object o)
     {
       if (o is Item item)
-        Spell.Target(item);
+        m_Spell.Target(item);
     }
 
     protected override void OnTargetFinish(Mobile from)
     {
-      Spell?.FinishSequence();
+      m_Spell?.FinishSequence();
     }
   }
 }

--- a/Scripts/Spells/Targeting/SpellTargetMobile.cs
+++ b/Scripts/Spells/Targeting/SpellTargetMobile.cs
@@ -18,8 +18,7 @@ namespace Server.Spells
 
     protected override void OnTarget(Mobile from, object o)
     {
-      if (o is Mobile mobile)
-        Spell.Target(mobile);
+      Spell.Target(o as Mobile);
     }
 
     protected override void OnTargetFinish(Mobile from)

--- a/Scripts/Spells/Targeting/SpellTargetMobile.cs
+++ b/Scripts/Spells/Targeting/SpellTargetMobile.cs
@@ -1,0 +1,30 @@
+using Server.Targeting;
+
+namespace Server.Spells
+{
+  public interface ISpellTargetingMobile : ISpell
+  {
+    void Target(Mobile from);
+  }
+
+  public class SpellTargetMobile : Target
+  {
+    public ISpellTargetingMobile Spell{ get; }
+
+    public SpellTargetMobile(ISpellTargetingMobile spell, TargetFlags flags, int range = 12) : base(range, false, flags)
+    {
+      Spell = spell;
+    }
+
+    protected override void OnTarget(Mobile from, object o)
+    {
+      if (o is Mobile mobile)
+        Spell.Target(mobile);
+    }
+
+    protected override void OnTargetFinish(Mobile from)
+    {
+      Spell?.FinishSequence();
+    }
+  }
+}

--- a/Scripts/Spells/Targeting/SpellTargetMobile.cs
+++ b/Scripts/Spells/Targeting/SpellTargetMobile.cs
@@ -7,23 +7,24 @@ namespace Server.Spells
     void Target(Mobile from);
   }
 
-  public class SpellTargetMobile : Target
+  public class SpellTargetMobile : Target, ISpellTarget
   {
-    public ISpellTargetingMobile Spell{ get; }
+    private ISpellTargetingMobile m_Spell;
+    public ISpell Spell => m_Spell;
 
     public SpellTargetMobile(ISpellTargetingMobile spell, TargetFlags flags, int range = 12) : base(range, false, flags)
     {
-      Spell = spell;
+      m_Spell = spell;
     }
 
     protected override void OnTarget(Mobile from, object o)
     {
-      Spell.Target(o as Mobile);
+      m_Spell.Target(o as Mobile);
     }
 
     protected override void OnTargetFinish(Mobile from)
     {
-      Spell?.FinishSequence();
+      m_Spell?.FinishSequence();
     }
   }
 }

--- a/Scripts/Spells/Targeting/SpellTargetPoint3D.cs
+++ b/Scripts/Spells/Targeting/SpellTargetPoint3D.cs
@@ -10,19 +10,21 @@ namespace Server.Spells
 
   public class SpellTargetPoint3D : Target
   {
-    public ISpellTargetingPoint3D Spell{ get; private set; }
+    private ISpellTargetingPoint3D m_Spell;
+    public ISpell Spell => m_Spell;
+
     private bool m_CheckLOS;
 
     public SpellTargetPoint3D(ISpellTargetingPoint3D spell, TargetFlags flags = TargetFlags.None, int range = 12, bool checkLOS = true) : base(range, true, flags)
     {
-      Spell = spell;
+      m_Spell = spell;
       m_CheckLOS = checkLOS;
     }
 
     protected override void OnTarget(Mobile from, object o)
     {
       if (o is IPoint3D p)
-        Spell.Target(p);
+        m_Spell.Target(p);
     }
 
     protected override void OnTargetOutOfLOS(Mobile from, object o)
@@ -31,14 +33,14 @@ namespace Server.Spells
         return;
 
       from.SendLocalizedMessage(501943); // Target cannot be seen. Try again.
-      from.Target = new SpellTargetPoint3D(Spell);
+      from.Target = new SpellTargetPoint3D(m_Spell);
       from.Target.BeginTimeout(from, TimeoutTime - DateTime.UtcNow);
-      Spell = null;
+      m_Spell = null; // Needed?
     }
 
     protected override void OnTargetFinish(Mobile from)
     {
-      Spell?.FinishSequence();
+      m_Spell?.FinishSequence();
     }
   }
 }

--- a/Scripts/Spells/Targeting/SpellTargetPoint3D.cs
+++ b/Scripts/Spells/Targeting/SpellTargetPoint3D.cs
@@ -1,0 +1,44 @@
+using System;
+using Server.Targeting;
+
+namespace Server.Spells
+{
+  public interface ISpellTargetingPoint3D : ISpell
+  {
+    void Target(IPoint3D p);
+  }
+
+  public class SpellTargetPoint3D : Target
+  {
+    public ISpellTargetingPoint3D Spell{ get; private set; }
+    private bool m_CheckLOS;
+
+    public SpellTargetPoint3D(ISpellTargetingPoint3D spell, TargetFlags flags = TargetFlags.None, int range = 12, bool checkLOS = true) : base(range, true, flags)
+    {
+      Spell = spell;
+      m_CheckLOS = checkLOS;
+    }
+
+    protected override void OnTarget(Mobile from, object o)
+    {
+      if (o is IPoint3D p)
+        Spell.Target(p);
+    }
+
+    protected override void OnTargetOutOfLOS(Mobile from, object o)
+    {
+      if (!m_CheckLOS)
+        return;
+
+      from.SendLocalizedMessage(501943); // Target cannot be seen. Try again.
+      from.Target = new SpellTargetPoint3D(Spell);
+      from.Target.BeginTimeout(from, TimeoutTime - DateTime.UtcNow);
+      Spell = null;
+    }
+
+    protected override void OnTargetFinish(Mobile from)
+    {
+      Spell?.FinishSequence();
+    }
+  }
+}

--- a/Scripts/Spells/Third/Bless.cs
+++ b/Scripts/Spells/Third/Bless.cs
@@ -4,7 +4,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Third
 {
-  public class BlessSpell : MagerySpell
+  public class BlessSpell : MagerySpell, ISpellTargetingMobile
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Bless", "Rel Sanct",
@@ -33,15 +33,16 @@ namespace Server.Spells.Third
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetMobile(this, TargetFlags.Beneficial, Core.ML ? 10 : 12);
     }
 
     public void Target(Mobile m)
     {
+      if (m == null)
+        return;
+
       if (!Caster.CanSee(m))
-      {
         Caster.SendLocalizedMessage(500237); // Target can not be seen.
-      }
       else if (CheckBSequence(m))
       {
         SpellHelper.Turn(Caster, m);
@@ -64,27 +65,6 @@ namespace Server.Spells.Third
       }
 
       FinishSequence();
-    }
-
-    private class InternalTarget : Target
-    {
-      private BlessSpell m_Owner;
-
-      public InternalTarget(BlessSpell owner) : base(Core.ML ? 10 : 12, false, TargetFlags.Beneficial)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is Mobile mobile)
-          m_Owner.Target(mobile);
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
-      }
     }
   }
 }

--- a/Scripts/Spells/Third/Fireball.cs
+++ b/Scripts/Spells/Third/Fireball.cs
@@ -2,7 +2,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Third
 {
-  public class FireballSpell : MagerySpell
+  public class FireballSpell : MagerySpell, ISpellTargetingMobile
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Fireball", "Vas Flam",
@@ -21,15 +21,16 @@ namespace Server.Spells.Third
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetMobile(this, TargetFlags.Harmful, Core.ML ? 10 : 12);
     }
 
     public void Target(Mobile m)
     {
+      if (m == null)
+        return;
+
       if (!Caster.CanSee(m))
-      {
         Caster.SendLocalizedMessage(500237); // Target can not be seen.
-      }
       else if (CheckHSequence(m))
       {
         Mobile source = Caster;
@@ -65,27 +66,6 @@ namespace Server.Spells.Third
       }
 
       FinishSequence();
-    }
-
-    private class InternalTarget : Target
-    {
-      private FireballSpell m_Owner;
-
-      public InternalTarget(FireballSpell owner) : base(Core.ML ? 10 : 12, false, TargetFlags.Harmful)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is Mobile mobile)
-          m_Owner.Target(mobile);
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
-      }
     }
   }
 }

--- a/Scripts/Spells/Third/MagicLock.cs
+++ b/Scripts/Spells/Third/MagicLock.cs
@@ -5,7 +5,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Third
 {
-  public class MagicLockSpell : MagerySpell
+  public class MagicLockSpell : MagerySpell, ISpellTargetingItem
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Magic Lock", "An Por",
@@ -24,64 +24,37 @@ namespace Server.Spells.Third
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetItem(this, TargetFlags.None, Core.ML ? 10 : 12);
     }
 
-    public void Target(LockableContainer targ)
+    public void Target(Item item)
     {
-      if (BaseHouse.CheckLockedDownOrSecured(targ))
-      {
-        // You cannot cast this on a locked down item.
-        Caster.LocalOverheadMessage(MessageType.Regular, 0x22, 501761);
-      }
-      else if (targ.Locked || targ.LockLevel == 0 || targ is ParagonChest)
-      {
-        // Target must be an unlocked chest.
-        Caster.SendLocalizedMessage(501762);
-      }
+      if (!(item is LockableContainer cont))
+        Caster.SendLocalizedMessage(501762); // Target must be an unlocked chest.
+      else if (BaseHouse.CheckLockedDownOrSecured(cont))
+        Caster.LocalOverheadMessage(MessageType.Regular, 0x22, 501761); // You cannot cast this on a locked down item.
+      else if (cont.Locked || cont.LockLevel == 0 || cont is ParagonChest)
+        Caster.SendLocalizedMessage(501762); // Target must be an unlocked chest.
       else if (CheckSequence())
       {
-        SpellHelper.Turn(Caster, targ);
+        SpellHelper.Turn(Caster, cont);
 
-        Point3D loc = targ.GetWorldLocation();
+        Point3D loc = cont.GetWorldLocation();
 
         Effects.SendLocationParticles(
-          EffectItem.Create(loc, targ.Map, EffectItem.DefaultDuration),
+          EffectItem.Create(loc, cont.Map, EffectItem.DefaultDuration),
           0x376A, 9, 32, 5020);
 
-        Effects.PlaySound(loc, targ.Map, 0x1FA);
+        Effects.PlaySound(loc, cont.Map, 0x1FA);
 
         // The chest is now locked!
         Caster.LocalOverheadMessage(MessageType.Regular, 0x3B2, 501763);
 
-        targ.LockLevel = -255; // signal magic lock
-        targ.Locked = true;
+        cont.LockLevel = -255; // signal magic lock
+        cont.Locked = true;
       }
 
       FinishSequence();
-    }
-
-    private class InternalTarget : Target
-    {
-      private MagicLockSpell m_Owner;
-
-      public InternalTarget(MagicLockSpell owner) : base(Core.ML ? 10 : 12, false, TargetFlags.None)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is LockableContainer container)
-          m_Owner.Target(container);
-        else
-          from.SendLocalizedMessage(501762); // Target must be an unlocked chest.
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
-      }
     }
   }
 }

--- a/Scripts/Spells/Third/Poison.cs
+++ b/Scripts/Spells/Third/Poison.cs
@@ -3,7 +3,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Third
 {
-  public class PoisonSpell : MagerySpell
+  public class PoisonSpell : MagerySpell, ISpellTargetingMobile
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Poison", "In Nox",
@@ -20,15 +20,16 @@ namespace Server.Spells.Third
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetMobile(this, TargetFlags.Harmful, Core.ML ? 10 : 12);
     }
 
     public void Target(Mobile m)
     {
+      if (m == null)
+        return;
+
       if (!Caster.CanSee(m))
-      {
         Caster.SendLocalizedMessage(500237); // Target can not be seen.
-      }
       else if (CheckHSequence(m))
       {
         SpellHelper.Turn(Caster, m);
@@ -77,11 +78,8 @@ namespace Server.Spells.Third
 
             if (Caster is PlayerMobile pm)
             {
-              if (pm.DuelContext != null && pm.DuelContext.Started && !pm.DuelContext.Finished &&
-                  !pm.DuelContext.Ruleset.GetOption("Skills", "Poisoning"))
-              {
-              }
-              else
+              if (pm.DuelContext == null || !pm.DuelContext.Started || pm.DuelContext.Finished ||
+                  pm.DuelContext.Ruleset.GetOption("Skills", "Poisoning"))
               {
                 total += pm.Skills.Poisoning.Value;
               }
@@ -118,26 +116,6 @@ namespace Server.Spells.Third
       }
 
       FinishSequence();
-    }
-
-    private class InternalTarget : Target
-    {
-      private PoisonSpell m_Owner;
-
-      public InternalTarget(PoisonSpell owner) : base(Core.ML ? 10 : 12, false, TargetFlags.Harmful)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is Mobile mobile) m_Owner.Target(mobile);
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
-      }
     }
   }
 }

--- a/Scripts/Spells/Third/Telekinesis.cs
+++ b/Scripts/Spells/Third/Telekinesis.cs
@@ -3,7 +3,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Third
 {
-  public class TelekinesisSpell : MagerySpell
+  public class TelekinesisSpell : MagerySpell, ISpellTargetingItem
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Telekinesis", "Ort Por Ylem",
@@ -21,77 +21,55 @@ namespace Server.Spells.Third
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetItem(this, TargetFlags.None, Core.ML ? 10 : 12);
     }
 
-    public void Target(ITelekinesisable obj)
+    public void Target(Item item)
     {
+      ITelekinesisable t = item as ITelekinesisable;
+      if (!(t != null || item is Container))
+      {
+        Caster.SendLocalizedMessage(501857); // This spell won't work on that!
+        return;
+      }
+
       if (CheckSequence())
       {
-        SpellHelper.Turn(Caster, obj);
-
-        obj.OnTelekinesis(Caster);
-      }
-
-      FinishSequence();
-    }
-
-    public void Target(Container item)
-    {
-      if (CheckSequence())
-      {
-        SpellHelper.Turn(Caster, item);
-
-        if (!item.IsAccessibleTo(Caster))
+        if (t != null)
         {
-          item.OnDoubleClickNotAccessible(Caster);
+          SpellHelper.Turn(Caster, t);
+          t.OnTelekinesis(Caster);
         }
-        else if (!item.CheckItemUse(Caster, item))
-        {
-        }
-        else if (item.RootParent is Mobile && item.RootParent != Caster)
-        {
-          item.OnSnoop(Caster);
-        }
-        else if (item is Corpse corpse && !corpse.CheckLoot(Caster, null))
-        {
-        }
-        else if (Caster.Region.OnDoubleClick(Caster, item))
-        {
-          Effects.SendLocationParticles(EffectItem.Create(item.Location, item.Map, EffectItem.DefaultDuration),
-            0x376A, 9, 32, 5022);
-          Effects.PlaySound(item.Location, item.Map, 0x1F5);
-
-          item.OnItemUsed(Caster, item);
-        }
-      }
-
-      FinishSequence();
-    }
-
-    public class InternalTarget : Target
-    {
-      private TelekinesisSpell m_Owner;
-
-      public InternalTarget(TelekinesisSpell owner) : base(Core.ML ? 10 : 12, false, TargetFlags.None)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is ITelekinesisable telekinesisable)
-          m_Owner.Target(telekinesisable);
-        else if (o is Container container)
-          m_Owner.Target(container);
         else
-          from.SendLocalizedMessage(501857); // This spell won't work on that!
+        {
+          SpellHelper.Turn(Caster, item);
+
+          if (!item.IsAccessibleTo(Caster))
+          {
+            item.OnDoubleClickNotAccessible(Caster);
+          }
+          else if (!item.CheckItemUse(Caster, item))
+          {
+          }
+          else if (item.RootParent is Mobile && item.RootParent != Caster)
+          {
+            item.OnSnoop(Caster);
+          }
+          else if (item is Corpse corpse && !corpse.CheckLoot(Caster, null))
+          {
+          }
+          else if (Caster.Region.OnDoubleClick(Caster, item))
+          {
+            Effects.SendLocationParticles(EffectItem.Create(item.Location, item.Map, EffectItem.DefaultDuration),
+              0x376A, 9, 32, 5022);
+            Effects.PlaySound(item.Location, item.Map, 0x1F5);
+
+            item.OnItemUsed(Caster, item);
+          }
+        }
       }
 
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
-      }
+      FinishSequence();
     }
   }
 }

--- a/Scripts/Spells/Third/Teleport.cs
+++ b/Scripts/Spells/Third/Teleport.cs
@@ -9,7 +9,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Third
 {
-  public class TeleportSpell : MagerySpell
+  public class TeleportSpell : MagerySpell, ISpellTargetingPoint3D
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Teleport", "Rel Por",
@@ -44,7 +44,7 @@ namespace Server.Spells.Third
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetPoint3D(this, TargetFlags.None, Core.ML ? 10 : 12);
     }
 
     public void Target(IPoint3D p)
@@ -117,27 +117,6 @@ namespace Server.Spells.Third
       }
 
       FinishSequence();
-    }
-
-    public class InternalTarget : Target
-    {
-      private TeleportSpell m_Owner;
-
-      public InternalTarget(TeleportSpell owner) : base(Core.ML ? 11 : 12, true, TargetFlags.None)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is IPoint3D p)
-          m_Owner.Target(p);
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
-      }
     }
   }
 }

--- a/Scripts/Spells/Third/WallOfStone.cs
+++ b/Scripts/Spells/Third/WallOfStone.cs
@@ -5,7 +5,7 @@ using Server.Targeting;
 
 namespace Server.Spells.Third
 {
-  public class WallOfStoneSpell : MagerySpell
+  public class WallOfStoneSpell : MagerySpell, ISpellTargetingPoint3D
   {
     private static SpellInfo m_Info = new SpellInfo(
       "Wall of Stone", "In Sanct Ylem",
@@ -24,7 +24,7 @@ namespace Server.Spells.Third
 
     public override void OnCast()
     {
-      Caster.Target = new InternalTarget(this);
+      Caster.Target = new SpellTargetPoint3D(this, TargetFlags.None, Core.ML ? 10 : 12);
     }
 
     public void Target(IPoint3D p)
@@ -187,27 +187,6 @@ namespace Server.Spells.Third
         {
           m_Item.Delete();
         }
-      }
-    }
-
-    private class InternalTarget : Target
-    {
-      private WallOfStoneSpell m_Owner;
-
-      public InternalTarget(WallOfStoneSpell owner) : base(Core.ML ? 10 : 12, true, TargetFlags.None)
-      {
-        m_Owner = owner;
-      }
-
-      protected override void OnTarget(Mobile from, object o)
-      {
-        if (o is IPoint3D d)
-          m_Owner.Target(d);
-      }
-
-      protected override void OnTargetFinish(Mobile from)
-      {
-        m_Owner.FinishSequence();
       }
     }
   }

--- a/Server/Interfaces.cs
+++ b/Server/Interfaces.cs
@@ -86,6 +86,7 @@ namespace Server
     bool OnCasterEquipping(Item item);
     bool OnCasterUsingObject(IEntity entity);
     bool OnCastInTown(Region r);
+    void FinishSequence();
   }
 
   public interface IParty

--- a/Server/Item.cs
+++ b/Server/Item.cs
@@ -1090,10 +1090,10 @@ namespace Server
           } else if (ObjectPropertyList.Enabled && (flags & ItemDelta.Properties) != 0)
             state.Send(OPLPacket);
         }
-
-        Packet.Release(p);
-        eable.Free();
       }
+
+      Packet.Release(p);
+      eable.Free();
     }
 
     public virtual void Delete()

--- a/Server/Items/Container.cs
+++ b/Server/Items/Container.cs
@@ -19,7 +19,6 @@
  ***************************************************************************/
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using Server.Network;

--- a/Server/Mobile.cs
+++ b/Server/Mobile.cs
@@ -2333,9 +2333,7 @@ namespace Server
     public virtual void ProcessDelta()
     {
       Mobile m = this;
-      MobileDelta delta;
-
-      delta = m.m_DeltaFlags;
+      MobileDelta delta = m.m_DeltaFlags;
 
       if (delta == MobileDelta.None)
         return;
@@ -7282,12 +7280,14 @@ namespace Server
       }
       else
       {
-        while (m_DeltaQueue.Count > 0) m_DeltaQueue.Dequeue().ProcessDelta();
+        while (m_DeltaQueue.Count > 0)
+          m_DeltaQueue.Dequeue().ProcessDelta();
       }
 
       _processing = false;
 
-      while (m_DeltaQueueR.Count > 0) m_DeltaQueueR.Dequeue().ProcessDelta();
+      while (m_DeltaQueueR.Count > 0)
+        m_DeltaQueueR.Dequeue().ProcessDelta();
     }
 
     public virtual void OnKillsChange(int oldValue)


### PR DESCRIPTION
- [X] Creates specific spell target objects which eventually can be pooled.
- [X] Fixes several sequence bugs.

*BREAKING CHANGE*: AI updated to find out which spell target it is using. This will break custom AI like NecroAI, but the fix is easy.

*BREAKING CHANGE*: `ISpell` in the core has been changed. `FinishSequence()` was added.